### PR TITLE
feat(mise): manage global config via install script instead of dotfiles symlink

### DIFF
--- a/docs/development/01-project-structure.md
+++ b/docs/development/01-project-structure.md
@@ -15,7 +15,6 @@
 │   ├── tmux.conf           # -> ~/.tmux.conf
 │   ├── gitconfig           # -> ~/.gitconfig
 │   ├── ghostty/            # -> ~/.config/ghostty
-│   ├── mise/               # -> ~/.config/mise
 │   ├── nvim/               # -> ~/.config/nvim (LazyVim)
 │   ├── sheldon/            # -> ~/.config/sheldon
 │   ├── starship.toml       # -> ~/.config/starship.toml

--- a/docs/reference/mise.md
+++ b/docs/reference/mise.md
@@ -2,23 +2,24 @@
 
 開発ツールバージョン管理（mise）の設定リファレンスです。
 
-## ファイル
+## グローバル設定
 
-`dotfiles/mise/config.toml` → `~/.config/mise/config.toml`
+グローバル設定（`~/.config/mise/config.toml`）は dotfiles では管理しません。セットアップ時に `scripts/100-mise.sh` が `mise settings` コマンドで自動的に設定します。
 
-## ツール定義
-
-### `dotfiles/mise/config.toml`（グローバル）
-
-グローバル設定ではツールを管理していません。`[settings.github]` のみを定義します。
-
-```toml
-[settings.github]
-credential_command = "gh auth token"
+```bash
+# 100-mise.sh が実行するコマンド（冪等）
+mise settings set github.credential_command "gh auth token"
 ```
 
-> [!NOTE]
-> 以前は `node` / `bun` / `npm:markdownlint-cli2` を mise で管理していましたが、`node` と `bun` は Homebrew（`Brewfile`）管理へ移行し、`markdownlint-cli2` は廃止しました。詳細は [ツール一覧](./tools.md) を参照してください。
+これにより `~/.config/mise/config.toml` はマシンごとに mise が管理するファイルとなり、`mise use -g <tool>` で追加したプライベートツールなども自由に記述できます。
+
+### `[settings.github]`
+
+| キー                 | 値                | 説明                                            |
+| -------------------- | ----------------- | ----------------------------------------------- |
+| `credential_command` | `"gh auth token"` | GitHub API アクセスに `gh` の認証トークンを使用 |
+
+## リポジトリローカル設定
 
 ### `mise.toml`（リポジトリルート）
 
@@ -30,20 +31,12 @@ dotfiles リポジトリ自体の開発環境を定義します。
 
 `[hooks]` セクションで `postinstall = "bun install --frozen-lockfile"` が設定されており、`mise install` 後に依存関係が自動インストールされます。
 
-## 設定
-
-### `[settings]`（リポジトリルートの `mise.toml`）
+### `[settings]`（`mise.toml`）
 
 | キー           | 値     | 説明                                 |
 | -------------- | ------ | ------------------------------------ |
 | `lockfile`     | `true` | ロックファイルを生成（再現性のため） |
 | `experimental` | `true` | 実験的機能を有効化                   |
-
-### `[settings.github]`（グローバルの `config.toml`）
-
-| キー                 | 値                | 説明                                            |
-| -------------------- | ----------------- | ----------------------------------------------- |
-| `credential_command` | `"gh auth token"` | GitHub API アクセスに `gh` の認証トークンを使用 |
 
 ## シェル統合
 
@@ -52,10 +45,10 @@ dotfiles リポジトリ自体の開発環境を定義します。
 ## ツールの追加
 
 ```bash
-# グローバルに追加
-mise use --global python@latest
+# グローバルに追加（~/.config/mise/config.toml に書き込まれる）
+mise use -g python@latest
 
-# config.toml に手動追加
-[tools]
-python = "latest"
+# ツールバージョンを確認
+mise ls --current
 ```
+

--- a/dotfiles/mise/config.toml
+++ b/dotfiles/mise/config.toml
@@ -1,2 +1,0 @@
-[settings.github]
-credential_command = "gh auth token"

--- a/install_map.json
+++ b/install_map.json
@@ -5,7 +5,6 @@
     "tmux.conf": "~/.tmux.conf",
     "gitconfig": "~/.gitconfig",
     "ghostty": "~/.config/ghostty",
-    "mise": "~/.config/mise",
     "nvim": "~/.config/nvim",
     "sheldon": "~/.config/sheldon",
     "starship.toml": "~/.config/starship.toml",

--- a/scripts/100-mise.sh
+++ b/scripts/100-mise.sh
@@ -6,4 +6,5 @@ else
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
 
+mise settings set github.credential_command "gh auth token"
 mise install


### PR DESCRIPTION
## 目的

`dotfiles/mise/config.toml` を dotfiles リポジトリの git 管理から外し、グローバルな mise 設定をインストールスクリプトで行う方式に移行します。

## 背景

origin/main では `dotfiles/mise/` ディレクトリを `~/.config/mise/` へシンボリックリンクし、`config.toml` をリポジトリで管理していました。この構成だと `mise use -g <tool>` で書き込まれたすべての内容がリポジトリ管理下に入ってしまい、プライベートリポジトリのツール名などを誤ってコミットするリスクがありました。

この PR では：

- `dotfiles/mise/config.toml`（および `dotfiles/mise/` ディレクトリ）を削除
- `install_map.json` から `"mise"` エントリを削除（シンボリックリンクを廃止）
- `scripts/100-mise.sh` に `mise settings set github.credential_command "gh auth token"` を追加（冪等・セットアップ時に自動実行）

これにより `~/.config/mise/` は mise が管理する通常ディレクトリになり、`mise use -g <private-tool>` で追加したツールはリポジトリ外の `~/.config/mise/config.toml` に書き込まれます。
