### PR TITLE
fix(mise): remove stale symlink before creating config dir

### DIFF
--- a/scripts/100-mise.sh
+++ b/scripts/100-mise.sh
@@ -6,5 +6,9 @@ else
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
 
+if [[ -L ~/.config/mise ]]; then
+  rm ~/.config/mise
+fi
+mkdir -p ~/.config/mise
 mise settings set github.credential_command "gh auth token"
 mise install


### PR DESCRIPTION
## 目的

既存マシンで `100-mise.sh` を実行すると `~/.config/mise/` が壊れたシンボリックリンクのまま残っているため、`mkdir -p` が失敗して mise settings が書き込めないバグを修正します。

## 背景

#2 で `dotfiles/mise/` ディレクトリと `install_map.json` のシンボリックリンクエントリを削除しました。しかし、既存マシンの `~/.config/mise` は引き続き存在しない `dotfiles/mise/` を指す壊れたシンボリックリンクのままです。この状態で `mkdir -p ~/.config/mise` を実行しても、シンボリックリンク自体は消えないためディレクトリが作成されず、`mise settings set` が失敗します。

`100-mise.sh` でシンボリックリンクを検出した場合に事前に削除するコードを追加し、その後に `mkdir -p` でディレクトリを作成するよう修正します。
