### PR TITLE
docs: translate all documentation, comments, and skills to English

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,75 +1,75 @@
 # Copilot Instructions
 
-## コミットメッセージ
+## Commit messages
 
-- **英語**で書く
-- [Conventional Commits](https://www.conventionalcommits.org/) に従う: `<type>(<scope>): <description>`
-  - 例: `feat(starship): add SSH indicator to prompt`
-  - 種別: `feat`, `fix`, `docs`, `refactor`, `chore`
+- Write in **English**
+- Follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
+  - Example: `feat(starship): add SSH indicator to prompt`
+  - Types: `feat`, `fix`, `docs`, `refactor`, `chore`
 
-## ドキュメント構成
+## Documentation structure
 
-`docs/` 以下には Docusaurus で構築された GitHub Flavored Markdown のドキュメントを置く:
+Under `docs/`, place GitHub Flavored Markdown documentation built with Docusaurus:
 
-- `docs/guides/` — ユーザー向けガイド（セットアップと使い方）
-- `docs/reference/` — リファレンス（ツール一覧、設定仕様）
-- `docs/development/` — 貢献者向け情報（構成、スタイルガイド）
+- `docs/guides/` — user guides (setup and usage)
+- `docs/reference/` — reference (tool list, configuration specs)
+- `docs/development/` — contributor information (structure, style guide)
 - `docs/development/99-adr/` — Architecture Decision Records
 
-### ドキュメント対応表
+### Documentation mapping table
 
-| トピック           | パス                                        | 対象   |
-| ------------------ | ------------------------------------------- | ------ |
-| クイックスタート   | `docs/guides/01-quick-start.md`             | 利用者 |
-| インストール       | `docs/guides/02-installation.md`            | 利用者 |
-| リンク管理         | `docs/guides/03-managing-links.md`          | 利用者 |
-| Git identity       | `docs/guides/04-git-identity.md`            | 利用者 |
-| スキルの使い方     | `docs/guides/06-skills.md`                  | 利用者 |
-| Ghostty            | `docs/reference/ghostty.md`                 | 利用者 |
-| Git                | `docs/reference/git.md`                     | 利用者 |
-| mise               | `docs/reference/mise.md`                    | 利用者 |
-| Neovim             | `docs/reference/nvim.md`                    | 利用者 |
-| RTK                | `docs/reference/rtk.md`                     | 利用者 |
-| Sheldon            | `docs/reference/sheldon.md`                 | 利用者 |
-| Starship           | `docs/reference/starship.md`                | 利用者 |
-| tmux               | `docs/reference/tmux.md`                    | 利用者 |
-| Zsh                | `docs/reference/zsh/README.md`              | 利用者 |
-| Zsh plugins        | `docs/reference/zsh/plugins.md`             | 利用者 |
-| install_map.json   | `docs/reference/install-map.md`             | 利用者 |
-| gh-infra           | `docs/reference/gh-infra.md`                | 利用者 |
-| Scripts            | `docs/reference/scripts.md`                 | 利用者 |
-| Tools (Brewfile)   | `docs/reference/tools.md`                   | 利用者 |
-| Copilot Skills     | `docs/reference/skills.md`                  | 利用者 |
-| Project structure  | `docs/development/01-project-structure.md`  | 貢献者 |
-| Docs style         | `docs/development/02-docs-style.md`         | 貢献者 |
-| ADR index          | `docs/development/99-adr/README.md`         | 貢献者 |
-| Skills development | `docs/development/03-skills-development.md` | 貢献者 |
+| Topic              | Path                                        | Audience     |
+| ------------------ | ------------------------------------------- | ------------ |
+| Quick start        | `docs/guides/01-quick-start.md`             | Users        |
+| Installation       | `docs/guides/02-installation.md`            | Users        |
+| Link management    | `docs/guides/03-managing-links.md`          | Users        |
+| Git identity       | `docs/guides/04-git-identity.md`            | Users        |
+| How to use skills  | `docs/guides/06-skills.md`                  | Users        |
+| Ghostty            | `docs/reference/ghostty.md`                 | Users        |
+| Git                | `docs/reference/git.md`                     | Users        |
+| mise               | `docs/reference/mise.md`                    | Users        |
+| Neovim             | `docs/reference/nvim.md`                    | Users        |
+| RTK                | `docs/reference/rtk.md`                     | Users        |
+| Sheldon            | `docs/reference/sheldon.md`                 | Users        |
+| Starship           | `docs/reference/starship.md`                | Users        |
+| tmux               | `docs/reference/tmux.md`                    | Users        |
+| Zsh                | `docs/reference/zsh/README.md`              | Users        |
+| Zsh plugins        | `docs/reference/zsh/plugins.md`             | Users        |
+| install_map.json   | `docs/reference/install-map.md`             | Users        |
+| gh-infra           | `docs/reference/gh-infra.md`                | Users        |
+| Scripts            | `docs/reference/scripts.md`                 | Users        |
+| Tools (Brewfile)   | `docs/reference/tools.md`                   | Users        |
+| Copilot Skills     | `docs/reference/skills.md`                  | Users        |
+| Project structure  | `docs/development/01-project-structure.md`  | Contributors |
+| Docs style         | `docs/development/02-docs-style.md`         | Contributors |
+| ADR index          | `docs/development/99-adr/README.md`         | Contributors |
+| Skills development | `docs/development/03-skills-development.md` | Contributors |
 
-編集前に読むべきスタイル参照:
+Style reference to read before editing:
 
-- `docs/development/02-docs-style.md` — ドキュメント執筆スタイルガイド
+- `docs/development/02-docs-style.md` — documentation writing style guide
 
-## 必須ワークフロー
+## Required workflow
 
-1. コードを編集する前に、`docs/` 配下の関連文書を必ず読む（少なくとも該当セクションの `README` と関連ページ）。
-2. ドキュメントを編集する前に、`docs/development/02-docs-style.md` を必ず読んで、ドキュメント方針と規約を理解する。
-3. コード、スクリプト、設定を変更するときは、同じ変更内で必ず `docs/` も更新する。変更チェックリストと対象範囲の対応は `docs/development/02-docs-style.md` の "Documentation Strategy" セクションを参照する。
-4. 変更後は必ず、ドキュメントの正確性、リンク整合性、現在の実装に対する網羅性を確認する。
-5. 現在の文書構成が分かりにくい場合は、必要に応じて再編成する。
-6. ドキュメントは常に現在の実装と一致させる。更新を次のコミットに先送りしない。
-7. アーキテクチャや技術選定に複数の選択肢がある場合は、必ず `docs/development/99-adr/` に記録する。
+1. Before editing code, always read the related documents under `docs/` (at minimum, the relevant section `README` and related pages).
+2. Before editing documentation, always read `docs/development/02-docs-style.md` to understand the documentation policy and conventions.
+3. When changing code, scripts, or configuration, always update `docs/` in the same change. For the change checklist and scope mapping, refer to the "Documentation Strategy" section of `docs/development/02-docs-style.md`.
+4. After making changes, always verify documentation accuracy, link integrity, and coverage against the current implementation.
+5. If the current document structure is hard to understand, reorganize it as needed.
+6. Always keep documentation aligned with the current implementation. Do not defer updates to a later commit.
+7. If there are multiple options for architecture or technical choices, always record them in `docs/development/99-adr/`.
 
-## Docusaurus の規約
+## Docusaurus conventions
 
-- ファイル名はサイドバー順のために `01-` 形式の番号プレフィックスを付ける
-- セクションディレクトリ（`guides/`, `reference/`, `development/`）には番号プレフィックスを付けない
-- 各ディレクトリの `README.md` をインデックスページとする
-- リンクは相対パスかつ `.md` 拡張子付きで記述する
-- 各ページは `# h1` タイトルで始め、その後に説明段落を置く
+- Add a numeric prefix in the `01-` format to filenames for sidebar ordering
+- Do not add numeric prefixes to section directories (`guides/`, `reference/`, `development/`)
+- Use each directory's `README.md` as the index page
+- Write links as relative paths with the `.md` extension
+- Start each page with a `# h1` title, followed by an explanatory paragraph
 
-## 必須の品質基準
+## Required quality standards
 
-- ドキュメントには **何が変わったか**、**なぜ変わったか**、**どう操作するか** を必ず書く
-- 例やコマンドはそのままコピーして使える形にする
-- 古い案内や重複した案内は避ける
-- 意思決定の記録には明確な理由を含める
+- Documentation must always state **what changed**, **why it changed**, and **how to operate it**
+- Make examples and commands ready to copy and use as-is
+- Avoid outdated guidance and duplicated guidance
+- Include clear reasons in records of decisions

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # dotfiles
 
-macOS / Ubuntu (Codespaces) で統一された開発環境を再現するための dotfiles です。
+These dotfiles reproduce a unified development environment for macOS / Ubuntu (Codespaces).
 
-## セットアップ
+## Setup
 
 ```bash
 git clone https://github.com/daiksud/dotfiles.git ~/.dotfiles
@@ -10,20 +10,20 @@ cd ~/.dotfiles
 bash install.sh
 ```
 
-## 含まれるもの
+## Included
 
-| カテゴリ   | 内容                                                    |
-| ---------- | ------------------------------------------------------- |
-| シェル     | Zsh + Starship プロンプト + sheldon プラグイン          |
-| エディタ   | Neovim (LazyVim)                                        |
-| ターミナル | Ghostty + tmux                                          |
-| ツール管理 | Homebrew + mise                                         |
-| Git        | マルチアカウント自動切り替え (gh-config-dir) + SSH 署名 |
-| CLI        | gh, fzf, ripgrep, lazygit, jq                           |
+| Category        | Contents                                                |
+| --------------- | ------------------------------------------------------- |
+| Shell           | Zsh + Starship prompt + sheldon plugins                 |
+| Editor          | Neovim (LazyVim)                                        |
+| Terminal        | Ghostty + tmux                                          |
+| Tool management | Homebrew + mise                                         |
+| Git             | Automatic multi-account switching (gh-config-dir) + SSH signing |
+| CLI             | gh, fzf, ripgrep, lazygit, jq                           |
 
-## 仕組み
+## How it works
 
-`install_map.json` にシンボリックリンクの対応表を定義し、`install.sh` がそれに従ってリンクを作成します。
+`install_map.json` defines the symbolic link mapping table, and `install.sh` creates links based on it.
 
 ```json
 {
@@ -35,15 +35,15 @@ bash install.sh
 }
 ```
 
-詳細は [ドキュメント](./docs/README.mdx) を参照してください。
+For details, see the [documentation](./docs/README.mdx).
 
-## 対応プラットフォーム
+## Supported platforms
 
 - macOS (Apple Silicon)
 - Ubuntu (GitHub Codespaces)
 
-## ドキュメント
+## Documentation
 
-- [ガイド](./docs/guides/README.md) — セットアップから日常的な使い方まで
-- [リファレンス](./docs/reference/README.md) — 設定ファイル・ツール一覧の詳細
-- [開発者向け](./docs/development/README.md) — リポジトリ構造・カスタマイズ・ADR
+- [Guides](./docs/guides/README.md) — from setup to everyday usage
+- [Reference](./docs/reference/README.md) — details for configuration files and the tool list
+- [Development](./docs/development/README.md) — repository structure, customization, and ADRs

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ bash install.sh
 
 ## Included
 
-| Category        | Contents                                                |
-| --------------- | ------------------------------------------------------- |
-| Shell           | Zsh + Starship prompt + sheldon plugins                 |
-| Editor          | Neovim (LazyVim)                                        |
-| Terminal        | Ghostty + tmux                                          |
-| Tool management | Homebrew + mise                                         |
+| Category        | Contents                                                        |
+| --------------- | --------------------------------------------------------------- |
+| Shell           | Zsh + Starship prompt + sheldon plugins                         |
+| Editor          | Neovim (LazyVim)                                                |
+| Terminal        | Ghostty + tmux                                                  |
+| Tool management | Homebrew + mise                                                 |
 | Git             | Automatic multi-account switching (gh-config-dir) + SSH signing |
-| CLI             | gh, fzf, ripgrep, lazygit, jq                           |
+| CLI             | gh, fzf, ripgrep, lazygit, jq                                   |
 
 ## How it works
 

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -9,9 +9,9 @@ hide_table_of_contents: true
 
 # 🏠 daiksud/dotfiles
 
-macOS / Ubuntu (Codespaces) で統一された開発環境を再現するための dotfiles リポジトリです。
+This is a dotfiles repository for reproducing a unified development environment across macOS and Ubuntu (Codespaces).
 
-[クイックスタート →](./guides/01-quick-start.md) [GitHub](https://github.com/daiksud/dotfiles)
+[Quick Start →](./guides/01-quick-start.md) [GitHub](https://github.com/daiksud/dotfiles)
 
 </HeroLeft>
 <HeroRight>
@@ -26,55 +26,55 @@ $ cd ~/.dotfiles && ./install.sh
 </HeroRight>
 </Hero>
 
-## 特徴
+## Features
 
 <FeatureGrid>
 <Feature>
 
-⚡ **ワンコマンドセットアップ**
+⚡ **One-command setup**
 
-`install.sh` を実行するだけで、シェル・エディタ・ツール群がすべて揃います。
-
-</Feature>
-<Feature>
-
-🗺️ **JSON マッピング**
-
-`install_map.json` でシンボリックリンク先を柔軟に制御。追加も簡単。
+Just run `install.sh` to set up the shell, editor, and toolchain all at once.
 
 </Feature>
 <Feature>
 
-🌍 **マルチプラットフォーム**
+🗺️ **JSON mapping**
 
-macOS (Apple Silicon) と Ubuntu (Codespaces) の両方に対応しています。
-
-</Feature>
-<Feature>
-
-🔑 **自動 Git ID 切り替え**
-
-リポジトリごとに GitHub アカウントと SSH 署名鍵を自動で切り替えます。
+Use `install_map.json` to control symbolic link destinations flexibly. Adding new entries is easy too.
 
 </Feature>
 <Feature>
 
-🎨 **Tokyo Night Storm 統一テーマ**
+🌍 **Multi-platform**
 
-ターミナル・エディタ・プロンプトすべてを同じカラースキームで統一。
+Supports both macOS (Apple Silicon) and Ubuntu (Codespaces).
 
 </Feature>
 <Feature>
 
-🔌 **モダンツールチェイン**
+🔑 **Automatic Git identity switching**
 
-mise・Sheldon・Starship・Neovim で高速かつ再現性の高い環境を構築。
+Automatically switches GitHub accounts and SSH signing keys for each repository.
+
+</Feature>
+<Feature>
+
+🎨 **Unified Tokyo Night Storm theme**
+
+Uses the same color scheme across the terminal, editor, and prompt.
+
+</Feature>
+<Feature>
+
+🔌 **Modern toolchain**
+
+Build a fast and reproducible environment with mise, Sheldon, Starship, and Neovim.
 
 </Feature>
 </FeatureGrid>
 
-## ドキュメント
+## Documentation
 
-- [ガイド](./guides/README.md) — セットアップから日常的な使い方まで
-- [リファレンス](./reference/README.md) — 設定ファイル・ツール一覧の詳細
-- [開発者向け](./development/README.md) — リポジトリ構造・カスタマイズ・ADR
+- [Guides](./guides/README.md) — From setup to everyday usage
+- [Reference](./reference/README.md) — Details of configuration files and tool lists
+- [For developers](./development/README.md) — Repository structure, customization, and ADRs

--- a/docs/development/01-project-structure.md
+++ b/docs/development/01-project-structure.md
@@ -46,15 +46,15 @@ This page organizes the roles of the repository's main directories and files.
 
 ## Roles of the Main Files
 
-| Path               | Role                                                             | When to change it                               |
-| ------------------ | ---------------------------------------------------------------- | ----------------------------------------------- |
+| Path               | Role                                                                   | When to change it                                     |
+| ------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------- |
 | `install.sh`       | Entry point for setup. Orchestrates link creation and script execution | When changing link handling or script execution logic |
-| `install_map.json` | Mapping table for symbolic links                                 | When adding or changing link targets            |
-| `Brewfile`         | List of packages managed by Homebrew                             | When adding or removing tools                   |
-| `dotfiles/`        | Configuration files that are symlinked                           | When changing the settings for each tool        |
-| `scripts/`         | Setup scripts                                                    | When changing tool installation procedures      |
-| `.devcontainer/`   | Container definitions for GitHub Codespaces                      | When changing the Codespaces environment        |
-| `.gitignore`       | Exclusion settings for files not tracked by Git                  | When adding generated files such as `node_modules/` |
+| `install_map.json` | Mapping table for symbolic links                                       | When adding or changing link targets                  |
+| `Brewfile`         | List of packages managed by Homebrew                                   | When adding or removing tools                         |
+| `dotfiles/`        | Configuration files that are symlinked                                 | When changing the settings for each tool              |
+| `scripts/`         | Setup scripts                                                          | When changing tool installation procedures            |
+| `.devcontainer/`   | Container definitions for GitHub Codespaces                            | When changing the Codespaces environment              |
+| `.gitignore`       | Exclusion settings for files not tracked by Git                        | When adding generated files such as `node_modules/`   |
 
 ## Which Files Should Be Changed Together
 

--- a/docs/development/01-project-structure.md
+++ b/docs/development/01-project-structure.md
@@ -1,72 +1,72 @@
-# プロジェクト構成
+# Project Structure
 
-リポジトリの主要ディレクトリとファイルの役割を整理します。
+This page organizes the roles of the repository's main directories and files.
 
-## 全体像
+## Overview
 
 ```text
 .
-├── install.sh              # メインセットアップスクリプト
-├── install_map.json        # シンボリックリンク対応表
-├── Brewfile                # Homebrew パッケージ定義
-├── dotfiles/               # シンボリックリンク元ファイル群
+├── install.sh              # Main setup script
+├── install_map.json        # Symbolic link mapping table
+├── Brewfile                # Homebrew package definitions
+├── dotfiles/               # Files used as symbolic link sources
 │   ├── zshrc               # -> ~/.zshrc
-│   ├── zsh/                # -> ~/.zsh（カスタムプラグイン）
+│   ├── zsh/                # -> ~/.zsh (custom plugins)
 │   ├── tmux.conf           # -> ~/.tmux.conf
 │   ├── gitconfig           # -> ~/.gitconfig
 │   ├── ghostty/            # -> ~/.config/ghostty
 │   ├── nvim/               # -> ~/.config/nvim (LazyVim)
 │   ├── sheldon/            # -> ~/.config/sheldon
 │   ├── starship.toml       # -> ~/.config/starship.toml
-│   ├── skills/             # -> ~/.copilot/skills（Copilot スキル）
+│   ├── skills/             # -> ~/.copilot/skills (Copilot skills)
 │   └── copilot-instructions.md # -> ~/.copilot/copilot-instructions.md
-├── scripts/                # セットアップスクリプト群
+├── scripts/                # Setup scripts
 │   ├── 000-codespace.sh
 │   ├── 001-homebrew.sh
 │   ├── 002-brewfile.sh
 │   └── 100-*.sh
-├── docs/                   # ドキュメント
+├── docs/                   # Documentation
 │   ├── README.mdx
 │   ├── guides/
 │   ├── reference/
 │   └── development/
-├── .devcontainer/          # Codespaces 設定
-├── .docusaurus/            # Docusaurus サイト構築
+├── .devcontainer/          # Codespaces settings
+├── .docusaurus/            # Docusaurus site build
 ├── .github/
 │   ├── copilot-instructions.md
-│   ├── dependabot.yml      # bun / GitHub Actions の依存更新設定
-│   ├── settings.yml        # gh-infra による宣言的リポジトリ設定
+│   ├── dependabot.yml      # Dependency update settings for bun / GitHub Actions
+│   ├── settings.yml        # Declarative repository settings managed by gh-infra
 │   └── workflows/docs.yml
-├── mise.toml               # リポジトリローカルの mise 設定
-├── package.json            # ドキュメントビルド用スクリプト
-├── .gitignore              # 追跡しない生成物やローカルファイルの定義
+├── mise.toml               # Repository-local mise settings
+├── package.json            # Scripts for building the documentation
+├── .gitignore              # Definitions for untracked generated and local files
 ├── .editorconfig
 └── LICENSE
 ```
 
-## 主要ファイルの役割
+## Roles of the Main Files
 
-| パス               | 役割                                                             | 変更するタイミング                             |
-| ------------------ | ---------------------------------------------------------------- | ---------------------------------------------- |
-| `install.sh`       | セットアップのエントリポイント。リンク作成とスクリプト実行を統括 | リンク処理やスクリプト実行ロジックを変えるとき |
-| `install_map.json` | シンボリックリンクの対応表                                       | リンク先を追加・変更するとき                   |
-| `Brewfile`         | Homebrew で管理するパッケージ一覧                                | ツールを追加・削除するとき                     |
-| `dotfiles/`        | シンボリックリンクされる設定ファイル群                           | 各ツールの設定を変えるとき                     |
-| `scripts/`         | セットアップスクリプト群                                         | ツールのインストール手順を変えるとき           |
-| `.devcontainer/`   | GitHub Codespaces のコンテナ定義                                 | Codespaces 環境を変えるとき                    |
-| `.gitignore`       | Git で追跡しないファイルの除外設定                               | `node_modules/` などの生成物を追加するとき     |
+| Path               | Role                                                             | When to change it                               |
+| ------------------ | ---------------------------------------------------------------- | ----------------------------------------------- |
+| `install.sh`       | Entry point for setup. Orchestrates link creation and script execution | When changing link handling or script execution logic |
+| `install_map.json` | Mapping table for symbolic links                                 | When adding or changing link targets            |
+| `Brewfile`         | List of packages managed by Homebrew                             | When adding or removing tools                   |
+| `dotfiles/`        | Configuration files that are symlinked                           | When changing the settings for each tool        |
+| `scripts/`         | Setup scripts                                                    | When changing tool installation procedures      |
+| `.devcontainer/`   | Container definitions for GitHub Codespaces                      | When changing the Codespaces environment        |
+| `.gitignore`       | Exclusion settings for files not tracked by Git                  | When adding generated files such as `node_modules/` |
 
-## どのファイルを一緒に触るべきか
+## Which Files Should Be Changed Together
 
-### 新しいツールを追加するとき
+### When adding a new tool
 
-1. `Brewfile` — パッケージ追加
-2. `dotfiles/<config>` — 設定ファイル配置
-3. `install_map.json` — リンクエントリ追加
-4. `docs/reference/tools.md` — ツール一覧更新
-5. 必要に応じて `scripts/100-<tool>.sh` — セットアップスクリプト追加
+1. `Brewfile` — Add the package
+2. `dotfiles/<config>` — Place the configuration file
+3. `install_map.json` — Add the link entry
+4. `docs/reference/tools.md` — Update the tool list
+5. If needed, `scripts/100-<tool>.sh` — Add a setup script
 
-### Zsh プラグインを追加するとき
+### When adding a Zsh plugin
 
-1. `dotfiles/zsh/<name>.zsh` — プラグイン作成（`.zshrc` は編集不要、自動 source される）
-2. `docs/reference/zsh/plugins.md` — 一覧更新
+1. `dotfiles/zsh/<name>.zsh` — Create the plugin (`.zshrc` does not need editing; it is sourced automatically)
+2. `docs/reference/zsh/plugins.md` — Update the list

--- a/docs/development/02-docs-style.md
+++ b/docs/development/02-docs-style.md
@@ -1,114 +1,114 @@
-# ドキュメントスタイル
+# Documentation Style
 
-このリポジトリのドキュメント執筆ルールを定義します。
+This page defines the documentation writing rules for this repository.
 
-## Diátaxis に基づくセクション構成
+## Section Structure Based on Diátaxis
 
-`docs/` 以下は [Diátaxis フレームワーク](https://diataxis.fr/) の 4 象限に基づいて構成されています。
+Everything under `docs/` is organized according to the four quadrants of the [Diátaxis framework](https://diataxis.fr/).
 
-| Diátaxis 象限  | セクション                                         | 内容                       |
-| -------------- | -------------------------------------------------- | -------------------------- |
-| チュートリアル | `guides/01-quick-start.md`                         | 学習目標を持つ体験型ガイド |
-| How-to ガイド  | `guides/02-*` 〜 `guides/04-*`                     | タスク指向の手順書         |
-| リファレンス   | `reference/`                                       | 仕様の網羅的記述           |
-| 説明           | `guides/04-git-identity.md`, `development/99-adr/` | 設計思想・背景・意思決定   |
+| Diátaxis Quadrant | Section                                            | Content                                |
+| ----------------- | -------------------------------------------------- | -------------------------------------- |
+| Tutorial          | `guides/01-quick-start.md`                         | Guided, hands-on documentation with a learning goal |
+| How-to Guide      | `guides/02-*` to `guides/04-*`                     | Task-oriented procedures               |
+| Reference         | `reference/`                                       | Comprehensive specification            |
+| Explanation       | `guides/04-git-identity.md`, `development/99-adr/` | Design philosophy, background, and decisions |
 
-## ページの基本構造
+## Basic Page Structure
 
-すべてのページは `# h1` タイトルで始め、直後にそのページの概要を 1 文で書きます。
+Every page begins with a `# h1` title, followed immediately by a one-sentence summary of what the page covers.
 
 ```md
-# ページタイトル
+# Page Title
 
-このページで何が分かるかを 1 文で説明します。
+Explain in one sentence what the reader will learn on this page.
 
-## 最初のセクション
+## First Section
 
 ...
 ```
 
-## ファイル名と並び順
+## File Names and Ordering
 
-- セクションの入口は `README.md`（または `README.mdx`）
-- 個別ページは `01-topic.md`、`02-topic.md` のように連番を付ける
-- `docs/` 直下のセクションディレクトリには番号プリフィックスを付けない
+- The entry point for a section is `README.md` (or `README.mdx`)
+- Individual pages use sequential numbering such as `01-topic.md` and `02-topic.md`
+- Section directories directly under `docs/` do not use numeric prefixes
 
-## リンクの書き方
+## How to Write Links
 
-ドキュメント間リンクは**相対パスかつ `.md` 拡張子付き**で記述します。
+Links between documents must be written using **relative paths with the `.md` extension**.
 
 ```md
-<!-- ✅ 正しい -->
+<!-- ✅ Correct -->
 
-[クイックスタート](../guides/01-quick-start.md)
+[Quick Start](../guides/01-quick-start.md)
 
-<!-- ❌ 間違い -->
+<!-- ❌ Incorrect -->
 
-[クイックスタート](/guides/quick-start)
+[Quick Start](/guides/quick-start)
 ```
 
-## 図の活用
+## Using Diagrams
 
-Mermaid を使い、フローやアーキテクチャを図示します。
+Use Mermaid to illustrate flows and architecture.
 
 ````md
 ```mermaid
 graph LR
   A[install.sh] --> B[parse_links]
-  B --> C[symlink 作成]
+  B --> C[Create symlink]
 ```
 ````
 
-## Markdown の書き方
+## Writing Markdown
 
-- コードブロックには必ず言語名を付ける
-- パス、コマンド、識別子はバッククォートで囲む
-- 注記・警告には `> **Note**:` ではなく GitHub Alerts 記法を使用する
+- Always specify a language name for code blocks
+- Wrap paths, commands, and identifiers in backticks
+- For notes and warnings, use GitHub Alerts syntax instead of `> **Note**:`
 
   ```md
   > [!NOTE]
-  > 補足情報
+  > Supplementary information
 
   > [!WARNING]
-  > 注意が必要な情報
+  > Information that requires caution
 
   > [!IMPORTANT]
-  > 重要な情報
+  > Important information
   ```
 
-- コマンド例の先頭に `$` を付けない
+- Do not prefix example commands with `$`
 
-## 日本語の書き方
+## Writing Japanese
 
-- 基本は「です・ます調」で統一する
-- 1 文を長くしすぎない
-- 曖昧な表現より、実際の操作や結果を書き切る
+- Use polite Japanese style consistently (`desu/masu` style)
+- Avoid making individual sentences too long
+- Instead of ambiguous wording, fully describe the actual operation or result
 
-## ドキュメント戦略
+## Documentation Strategy
 
-コードとドキュメントは常に一致した状態を維持します。
+Keep code and documentation in sync at all times.
 
-### 原則
+### Principles
 
-- コードや設定に変更を加えたら、**同じコミットまたは同じ PR 内で**関連ドキュメントも更新する
-- ドキュメントの更新を「後でやる」としない。コード変更とドキュメント更新はセットで完了とする
-- 重要な技術判断は `99-adr/` に ADR として残す
+- When you change code or configuration, update the related documentation **in the same commit or the same PR**
+- Do not postpone documentation updates until later. A code change and its documentation update are complete only when both are done together
+- Record important technical decisions as ADRs under `99-adr/`
 
-### 変更時のチェックリスト
+### Checklist for Changes
 
-変更を行った際に以下を確認してください：
+When making changes, check the following:
 
-1. **追従確認** — 変更した機能・設定に言及しているドキュメントページはないか
-2. **正確性** — 既存の説明が古くなっていないか、コマンド例は正しいか
-3. **網羅性** — 新機能やオプションがリファレンスに記載されているか
-4. **リンク整合性** — ファイル名変更やディレクトリ移動でリンク切れが発生していないか
+1. **Follow-up check** — Are there documentation pages that mention the feature or setting you changed?
+2. **Accuracy** — Has any existing explanation become outdated, and are the example commands still correct?
+3. **Coverage** — Are new features and options documented in the reference?
+4. **Link integrity** — Did a file rename or directory move create any broken links?
 
-### 対象範囲
+### Scope
 
-| 変更内容                  | 確認すべきドキュメント                                                               |
-| ------------------------- | ------------------------------------------------------------------------------------ |
-| `install_map.json` の変更 | `reference/install-map.md`, `guides/03-managing-links.md`                            |
-| ツールの追加・削除        | `reference/tools.md`, 該当する個別リファレンス                                       |
-| スクリプトの変更          | `reference/scripts.md`                                                               |
-| スキルの追加・変更        | `reference/skills.md`, `guides/06-skills.md`, `development/03-skills-development.md` |
-| Docusaurus 設定変更       | `.docusaurus/README.md`                                                              |
+| Change                           | Documentation to review                                                               |
+| -------------------------------- | -------------------------------------------------------------------------------------- |
+| Changes to `install_map.json`    | `reference/install-map.md`, `guides/03-managing-links.md`                             |
+| Adding or removing tools         | `reference/tools.md`, the corresponding individual reference pages                     |
+| Changes to scripts               | `reference/scripts.md`                                                                 |
+| Adding or changing skills        | `reference/skills.md`, `guides/06-skills.md`, `development/03-skills-development.md`  |
+| Changes to Docusaurus settings   | `.docusaurus/README.md`                                                                |

--- a/docs/development/02-docs-style.md
+++ b/docs/development/02-docs-style.md
@@ -6,12 +6,12 @@ This page defines the documentation writing rules for this repository.
 
 Everything under `docs/` is organized according to the four quadrants of the [Diátaxis framework](https://diataxis.fr/).
 
-| Diátaxis Quadrant | Section                                            | Content                                |
-| ----------------- | -------------------------------------------------- | -------------------------------------- |
+| Diátaxis Quadrant | Section                                            | Content                                             |
+| ----------------- | -------------------------------------------------- | --------------------------------------------------- |
 | Tutorial          | `guides/01-quick-start.md`                         | Guided, hands-on documentation with a learning goal |
-| How-to Guide      | `guides/02-*` to `guides/04-*`                     | Task-oriented procedures               |
-| Reference         | `reference/`                                       | Comprehensive specification            |
-| Explanation       | `guides/04-git-identity.md`, `development/99-adr/` | Design philosophy, background, and decisions |
+| How-to Guide      | `guides/02-*` to `guides/04-*`                     | Task-oriented procedures                            |
+| Reference         | `reference/`                                       | Comprehensive specification                         |
+| Explanation       | `guides/04-git-identity.md`, `development/99-adr/` | Design philosophy, background, and decisions        |
 
 ## Basic Page Structure
 
@@ -105,10 +105,10 @@ When making changes, check the following:
 
 ### Scope
 
-| Change                           | Documentation to review                                                               |
-| -------------------------------- | -------------------------------------------------------------------------------------- |
-| Changes to `install_map.json`    | `reference/install-map.md`, `guides/03-managing-links.md`                             |
-| Adding or removing tools         | `reference/tools.md`, the corresponding individual reference pages                     |
-| Changes to scripts               | `reference/scripts.md`                                                                 |
-| Adding or changing skills        | `reference/skills.md`, `guides/06-skills.md`, `development/03-skills-development.md`  |
-| Changes to Docusaurus settings   | `.docusaurus/README.md`                                                                |
+| Change                         | Documentation to review                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------ |
+| Changes to `install_map.json`  | `reference/install-map.md`, `guides/03-managing-links.md`                            |
+| Adding or removing tools       | `reference/tools.md`, the corresponding individual reference pages                   |
+| Changes to scripts             | `reference/scripts.md`                                                               |
+| Adding or changing skills      | `reference/skills.md`, `guides/06-skills.md`, `development/03-skills-development.md` |
+| Changes to Docusaurus settings | `.docusaurus/README.md`                                                              |

--- a/docs/development/03-skills-development.md
+++ b/docs/development/03-skills-development.md
@@ -56,12 +56,12 @@ If you see a loading error, check whether the `name` and `description` in the fr
 
 ## Writing Rules
 
-| Rule                        | Reason                                              |
-| --------------------------- | --------------------------------------------------- |
-| Write in Japanese           | To keep both the body text and `description` in Japanese |
-| Write concrete steps        | Ambiguity makes the agent hesitate when deciding what to do |
-| State constraints clearly   | Prevents infinite loops and destructive operations  |
-| Define the output           | Clarifies what the user can expect                  |
+| Rule                      | Reason                                                      |
+| ------------------------- | ----------------------------------------------------------- |
+| Write in Japanese         | To keep both the body text and `description` in Japanese    |
+| Write concrete steps      | Ambiguity makes the agent hesitate when deciding what to do |
+| State constraints clearly | Prevents infinite loops and destructive operations          |
+| Define the output         | Clarifies what the user can expect                          |
 
 ## File Placement
 

--- a/docs/development/03-skills-development.md
+++ b/docs/development/03-skills-development.md
@@ -1,21 +1,21 @@
-# スキルの開発
+# Skill Development
 
-Copilot CLI カスタムスキルを新規作成・変更するためのガイドです。
+This is a guide for creating or modifying Copilot CLI custom skills.
 
-## 新しいスキルを作る
+## Create a New Skill
 
-### 1. ディレクトリとファイルを作成
+### 1. Create the directory and file
 
 ```bash
 mkdir dotfiles/skills/<skill-name>
 touch dotfiles/skills/<skill-name>/SKILL.md
 ```
 
-### 2. SKILL.md を書く
+### 2. Write `SKILL.md`
 
 ```markdown
 ---
-description: スキルの説明（1行、日本語）
+description: Skill description (one line, in Japanese)
 name: skill-name
 ---
 
@@ -44,43 +44,43 @@ What the user sees when the skill completes.
 - Limitations and failure behavior
 ```
 
-### 3. 動作確認
+### 3. Verify it works
 
-シンボリックリンクが設定済みなら、作成した時点でスキルは利用可能です：
+If the symbolic link is already set up, the skill is available as soon as you create it:
 
 ```bash
 copilot -p "/skill-name"
 ```
 
-ロードエラーが出る場合はフロントマターの `name` と `description` が正しいか確認してください。
+If you see a loading error, check whether the `name` and `description` in the frontmatter are correct.
 
-## 記述ルール
+## Writing Rules
 
-| ルール                 | 理由                                      |
-| ---------------------- | ----------------------------------------- |
-| 日本語で書く           | 本文も description も日本語で統一するため  |
-| ステップを具体的に書く | 曖昧だとエージェントが判断に迷う          |
-| 制約条件を明示する     | 無限ループや破壊的操作を防ぐ              |
-| 出力を定義する         | ユーザーが何を期待できるか明確にする      |
+| Rule                        | Reason                                              |
+| --------------------------- | --------------------------------------------------- |
+| Write in Japanese           | To keep both the body text and `description` in Japanese |
+| Write concrete steps        | Ambiguity makes the agent hesitate when deciding what to do |
+| State constraints clearly   | Prevents infinite loops and destructive operations  |
+| Define the output           | Clarifies what the user can expect                  |
 
-## ファイル配置
+## File Placement
 
 ```
 dotfiles/skills/
 └── <skill-name>/
-    └── SKILL.md       # 必須: スキル定義ファイル
+    └── SKILL.md       # Required: skill definition file
 ```
 
-- 1 スキル = 1 ディレクトリ
-- ディレクトリ名 = スキル名（ケバブケース）
-- 追加ファイル（テンプレートなど）を同ディレクトリに置くことも可能
+- 1 skill = 1 directory
+- Directory name = skill name (kebab-case)
+- You may also place additional files (such as templates) in the same directory
 
-## インストール
+## Installation
 
-`install_map.json` に `"skills": "~/.copilot/skills"` が登録済みのため、`install.sh` を実行すればシンボリックリンクが作成されます。既にリンクが存在する場合は何もしなくても新しいスキルが認識されます。
+Because `"skills": "~/.copilot/skills"` is already registered in `install_map.json`, running `install.sh` creates the symbolic link. If the link already exists, the new skill is recognized without any additional action.
 
-## テストのコツ
+## Testing Tips
 
-- スキルを書いたら実際に `copilot -p "/skill-name"` で呼び出して動作を確認する
-- エージェントが手順通りに動かない場合は、ステップの記述をより具体的にする
-- `Constraints` セクションで失敗時の振る舞い（リトライ回数、停止条件）を定義すると安定性が上がる
+- After writing a skill, actually invoke it with `copilot -p "/skill-name"` to confirm it works
+- If the agent does not follow the steps as intended, make the step descriptions more specific
+- Stability improves if you define failure behavior in the `Constraints` section, such as retry counts and stop conditions

--- a/docs/development/99-adr/0001-json-install-map.md
+++ b/docs/development/99-adr/0001-json-install-map.md
@@ -1,6 +1,6 @@
-# 0001: シンボリックリンク管理に JSON 対応表を採用
+# 0001: Adopt a JSON mapping table for symbolic link management
 
-シンボリックリンクの source→target マッピングを `install_map.json` で宣言的に管理する。
+Manage the source→target mapping for symbolic links declaratively in `install_map.json`.
 
 ## Status
 
@@ -8,16 +8,16 @@ Accepted
 
 ## Context
 
-従来はシェルグロブ (`dotfiles/.*`) で `dotfiles/` 以下の全ドットファイルを `~/` に一律リンクしていた。この方式には以下の課題があった:
+Previously, all dotfiles under `dotfiles/` were linked uniformly to `~/` using a shell glob (`dotfiles/.*`). This approach had the following issues:
 
-- `~/.config/X` のようなネストされたパスにリンクする手段がない
-- 任意のパス（`~/.copilot/skills` 等）へのリンクに対応できない
-- `dotfiles/` 内のファイル名がそのままリンク名になるため、命名の自由度がない
-- `.gitconfig` のような特殊処理が増え、スクリプトが複雑化していた
+- There was no way to link to nested paths such as `~/.config/X`
+- It could not support links to arbitrary paths such as `~/.copilot/skills`
+- Because file names under `dotfiles/` became link names as-is, naming flexibility was limited
+- Special handling for files like `.gitconfig` kept increasing, making the script more complex
 
 ## Decision
 
-リポジトリルートに `install_map.json` を配置し、JSON オブジェクトの key-value でマッピングを定義する。
+Place `install_map.json` at the repository root and define the mapping as key-value pairs in a JSON object.
 
 ```json
 {
@@ -29,35 +29,35 @@ Accepted
 }
 ```
 
-パースには Python3 の `json` モジュールを使用する（macOS / Ubuntu ともにプリインストール済み）。
+Use Python3's `json` module for parsing (preinstalled on both macOS and Ubuntu).
 
 ## Alternatives Considered
 
-### シンプルな行形式 (`source:target`)
+### Simple line format (`source:target`)
 
-- 実装が最も簡単
-- コメントや構造化が難しい
-- エディタのサポート（lint, schema validation）がない
+- Easiest to implement
+- Difficult to add comments or structure
+- No editor support (lint, schema validation)
 
 ### TOML
 
-- 可読性が高い
-- macOS / Ubuntu にプリインストールされたパーサーがない（Python3 の `tomllib` は 3.11+ のみ）
+- Highly readable
+- No parser is preinstalled on macOS / Ubuntu (`tomllib` in Python3 is only available in 3.11+)
 
 ### YAML
 
-- 可読性が高い
-- Python3 の標準ライブラリにパーサーがない（`PyYAML` が必要）
+- Highly readable
+- Python3 standard library does not include a parser (`PyYAML` is required)
 
-### bash 連想配列
+### bash associative arrays
 
-- 外部依存ゼロ
-- 配列内でのコメントやメンテナンス性が低い
-- bash 4.0+ 必須（macOS のデフォルト bash は 3.2）
+- Zero external dependencies
+- Poor support for comments inside the array and lower maintainability
+- Requires bash 4.0+ (the default bash on macOS is 3.2)
 
 ## Consequences
 
-- エントリの追加・削除が JSON ファイルの編集だけで完結する
-- `dotfiles/` 内のファイル名に `.` プリフィックスが不要になり、ファイル一覧が見やすくなる
-- Python3 への依存が生じるが、対象プラットフォーム（macOS, Ubuntu）ではシステム標準で利用可能
-- JSON はコメントが書けないが、エントリが自明なため問題にならない
+- Adding or removing entries is completed simply by editing the JSON file
+- File names under `dotfiles/` no longer need a `.` prefix, making the file list easier to read
+- This introduces a dependency on Python3, but it is available by default on the target platforms (macOS and Ubuntu)
+- JSON does not allow comments, but that is not a problem because the entries are self-explanatory

--- a/docs/development/99-adr/0002-ssh-commit-signing.md
+++ b/docs/development/99-adr/0002-ssh-commit-signing.md
@@ -1,4 +1,4 @@
-# ADR 0002: SSH コミット署名の採用
+# ADR 0002: Adopt SSH commit signing
 
 ## Status
 
@@ -6,40 +6,40 @@ Accepted
 
 ## Context
 
-Git コミット署名は真正性を保証し、GitHub の「Verified」バッジを有効にする。従来の方式は GPG 鍵だが、以下の課題がある:
+Git commit signing guarantees authenticity and enables GitHub's "Verified" badge. The traditional approach uses GPG keys, but it has the following issues:
 
-- 別途鍵の生成と管理が必要
-- macOS では `gpg` と `pinentry` の追加インストールが必要
-- 鍵の有効期限管理が煩雑
-- GitHub への鍵登録が認証鍵とは別に必要
+- It requires separate key generation and management
+- On macOS, additional installation of `gpg` and `pinentry` is required
+- Managing key expiration is cumbersome
+- Registering the key with GitHub is required separately from authentication keys
 
-開発者は GitHub 認証用に SSH 鍵をすでに持っているため、これを署名にも流用すればオーバーヘッドをゼロにできる。
+Because developers already have SSH keys for GitHub authentication, reusing them for signing reduces the overhead to zero.
 
 ## Decision
 
-既存の ed25519 SSH 鍵を使った SSH ベースのコミット署名を採用する。
+Adopt SSH-based commit signing using existing ed25519 SSH keys.
 
-グローバル gitconfig に設定:
+Configured in the global gitconfig:
 
-- `commit.gpgsign = true` — すべてのコミットを自動署名
-- `gpg.format = ssh` — GPG ではなく SSH 方式を使用
-- `gpg.ssh.allowedSignersFile = ~/.ssh/allowed_signers` — ローカル署名検証用
+- `commit.gpgsign = true` — automatically sign all commits
+- `gpg.format = ssh` — use SSH format instead of GPG
+- `gpg.ssh.allowedSignersFile = ~/.ssh/allowed_signers` — for local signature verification
 
-リポジトリごとの `user.signingkey` は `gh-config-dir.zsh` がアクティブな GitHub アカウントに応じて自動設定する（`~/.ssh/<login>.pub`）。
+The repository-specific `user.signingkey` is automatically set by `gh-config-dir.zsh` according to the active GitHub account (`~/.ssh/<login>.pub`).
 
 ## Alternatives Considered
 
-### GPG 署名
+### GPG signing
 
-不採用 — 追加ツール（`gpg`, `pinentry`）のインストール、独立した鍵ライフサイクル管理が必要で、SSH 署名に比べて実用上の利点がない。
+Not adopted — it requires installing additional tools (`gpg`, `pinentry`) and managing an independent key lifecycle, with no practical advantage over SSH signing.
 
-### 署名なし
+### No signing
 
-不採用 — マルチアカウント運用では「Verified」バッジがコミットの信頼性を示す重要な手段であり、SSH 鍵の流用で実質コストゼロで実現できる。
+Not adopted — in a multi-account workflow, the "Verified" badge is an important way to show commit trustworthiness, and reusing SSH keys makes it effectively free.
 
 ## Consequences
 
-- SSH 鍵を持つ開発者にとって追加セットアップがゼロ
-- `gh-config-dir.zsh` によりマルチアカウント署名が自動で動作
-- 各アカウントの `~/.ssh/<login>.pub` を GitHub の Signing Keys に登録する必要がある
-- `allowed_signers` は自動管理され、ローカルでの署名検証が可能
+- Zero additional setup for developers who already have SSH keys
+- Multi-account signing works automatically via `gh-config-dir.zsh`
+- `~/.ssh/<login>.pub` for each account must be registered in GitHub Signing Keys
+- `allowed_signers` is managed automatically, enabling local signature verification

--- a/docs/development/99-adr/0003-sheldon-starship.md
+++ b/docs/development/99-adr/0003-sheldon-starship.md
@@ -1,4 +1,4 @@
-# ADR 0003: Sheldon + Starship による Oh-My-Zsh の置き換え
+# ADR 0003: Replace Oh-My-Zsh with Sheldon + Starship
 
 ## Status
 
@@ -6,46 +6,46 @@ Accepted
 
 ## Context
 
-Oh-My-Zsh はプラグイン管理・テーマ・補完を一括提供するモノリシックなフレームワーク。以下の問題があった:
+Oh-My-Zsh is a monolithic framework that bundles plugin management, themes, and completion. It had the following problems:
 
-- フレームワーク全体（`lib/*.zsh`）をロードするためシェル起動が遅い
-- プラグイン管理が OMZ のディレクトリ構造に依存し、宣言的でない
-- テーマが OMZ 内部の関数に依存しており、他のシェルに移植できない
+- Shell startup was slow because the entire framework (`lib/*.zsh`) had to be loaded
+- Plugin management depended on OMZ's directory structure and was not declarative
+- Themes depended on internal OMZ functions and could not be ported to other shells
 
-目標は、高速な起動・宣言的で最小限のプラグイン管理・ポータブルなプロンプトの実現。
+The goal is to achieve fast startup, declarative and minimal plugin management, and a portable prompt.
 
 ## Decision
 
-Oh-My-Zsh を 2 つの専門ツールで置き換える:
+Replace Oh-My-Zsh with two specialized tools:
 
-- **Sheldon** — TOML 設定による宣言的プラグインマネージャ（`~/.config/sheldon/plugins.toml`）
-- **Starship** — Rust 製クロスシェルプロンプト（`~/.config/starship.toml`）
+- **Sheldon** — a declarative plugin manager configured with TOML (`~/.config/sheldon/plugins.toml`)
+- **Starship** — a Rust-based cross-shell prompt (`~/.config/starship.toml`)
 
-### プラグイン読み込み
+### Plugin loading
 
-必要なプラグインのみを `plugins.toml` に宣言する。OMZ の git プラグインは `ohmyzsh/ohmyzsh` リポジトリの `plugins/git` ディレクトリを直接参照する形で継続利用。
+Declare only the required plugins in `plugins.toml`. Continue using the OMZ git plugin by directly referencing the `plugins/git` directory in the `ohmyzsh/ohmyzsh` repository.
 
-### 重要な制約: compinit の順序
+### Important constraint: `compinit` order
 
-`compinit` は `sheldon source` の**前に**呼ぶ必要がある。fzf-tab など `compdef` を使うプラグインが正しく動作するため。
+`compinit` must be called **before** `sheldon source`. This is required so plugins that use `compdef`, such as fzf-tab, work correctly.
 
 ## Alternatives Considered
 
-### Oh-My-Zsh を維持
+### Keep Oh-My-Zsh
 
-不採用 — 不要なオーバーヘッドと非宣言的なプラグイン管理。
+Not adopted — unnecessary overhead and non-declarative plugin management.
 
 ### Zinit / Antidote
 
-検討した — いずれも有力な zsh プラグインマネージャ。Sheldon を選んだ理由は Rust 実装（高速）、TOML 設定（可読性）、ロックファイル機構。
+Considered — both are strong zsh plugin managers. Sheldon was chosen because of its Rust implementation (fast), TOML configuration (readable), and lockfile mechanism.
 
 ### Pure / Powerlevel10k
 
-プロンプトとして検討した — Starship を選んだ理由はクロスシェル互換性とシンプルな TOML 設定。
+Considered as prompts — Starship was chosen because of its cross-shell compatibility and simple TOML configuration.
 
 ## Consequences
 
-- シェル起動が高速化（宣言したプラグインのみロード）
-- `plugins.toml` が zsh プラグインの単一の信頼源
-- Starship の設定は bash, fish など他シェルでも再利用可能
-- Brew, gh, mise の OMZ プラグインは削除（これらのツールは独自のシェル統合を持つため）
+- Shell startup is faster because only declared plugins are loaded
+- `plugins.toml` becomes the single source of truth for zsh plugins
+- Starship configuration can be reused in other shells such as bash and fish
+- The OMZ plugins for Brew, gh, and mise are removed because those tools provide their own shell integrations

--- a/docs/development/99-adr/0004-gh-q.md
+++ b/docs/development/99-adr/0004-gh-q.md
@@ -1,4 +1,4 @@
-# ADR 0004: gh-q による ghq の置き換え
+# ADR 0004: Replace ghq with gh-q
 
 ## Status
 
@@ -6,33 +6,33 @@ Accepted
 
 ## Context
 
-`ghq` はローカルリポジトリを `~/ghq/<host>/<owner>/<repo>` の統一構造で管理する Go 製バイナリ。問題点:
+`ghq` is a Go binary that manages local repositories using the unified structure `~/ghq/<host>/<owner>/<repo>`. Its issues were:
 
-- Homebrew で別途インストールが必要
-- `gh` CLI の認証・API アクセスと分断されている
-- GitHub 固有の機能（starring, forking など）を活用できない
+- It requires separate installation via Homebrew
+- It is disconnected from `gh` CLI authentication and API access
+- It cannot take advantage of GitHub-specific features such as starring and forking
 
 ## Decision
 
-`ghq` を `gh-q`（GitHub CLI 拡張 `HikaruEgashira/gh-q`）で置き換える。
+Replace `ghq` with `gh-q` (the GitHub CLI extension `HikaruEgashira/gh-q`).
 
-- `gh extension install` でインストール
-- `gh` の認証を共有（別途設定不要）
-- 既存の zsh 関数（`ggr`, `egr`）と統合
+- Install it with `gh extension install`
+- Share `gh` authentication (no separate setup required)
+- Integrate it with the existing zsh functions (`ggr`, `egr`)
 
 ## Alternatives Considered
 
-### ghq を維持
+### Keep ghq
 
-不採用 — `gh` で代替できる機能のために別ツールを維持する理由がない。
+Not adopted — there is no reason to keep a separate tool for functionality that `gh` can replace.
 
-### gh api を使ったカスタムスクリプト
+### Custom scripts using `gh api`
 
-検討した — 動作はするが、ghq のローカルディレクトリ管理規約を持たない。`gh-q` はこれをそのまま提供する。
+Considered — workable, but they do not provide ghq's local directory management convention. `gh-q` provides that behavior directly.
 
 ## Consequences
 
-- `ghq` を Brewfile から削除
-- `go-to-ghq-repository.zsh` と `edit-ghq-repository.zsh` を `gh q` ベースに書き換え
-- 関数名・エイリアス（`ggr`, `egr`）は後方互換のため維持
-- リポジトリ管理が `gh` CLI エコシステムに統一される
+- Remove `ghq` from the Brewfile
+- Rewrite `go-to-ghq-repository.zsh` and `edit-ghq-repository.zsh` to use `gh q`
+- Keep the function names and aliases (`ggr`, `egr`) for backward compatibility
+- Repository management is unified within the `gh` CLI ecosystem

--- a/docs/development/99-adr/0005-gh-infra.md
+++ b/docs/development/99-adr/0005-gh-infra.md
@@ -1,6 +1,6 @@
-# ADR 0005: gh-infra による宣言的リポジトリ設定管理
+# ADR 0005: Manage repository settings declaratively with gh-infra
 
-`.github/settings.yml` と `gh-infra` 拡張でリポジトリ設定をコード管理する。
+Manage repository settings as code using `.github/settings.yml` and the `gh-infra` extension.
 
 ## Status
 
@@ -8,40 +8,40 @@ Accepted
 
 ## Context
 
-リポジトリのラベル・マージ戦略・ブランチ保護・セキュリティ設定などを GitHub の Web UI で手動管理すると、以下の課題がある。
+Managing repository labels, merge strategies, branch protection, and security settings manually in the GitHub Web UI has the following issues.
 
-- 設定がバージョン管理されず、いつ・なぜ変更したかが追えない
-- 同じ設定を再現・移植できない
-- レビューやプレビューなしに即時反映される
+- Settings are not version-controlled, so it is impossible to track when and why they changed
+- The same settings cannot be reproduced or migrated easily
+- Changes are applied immediately without review or preview
 
-これらを宣言的に、かつ `gh` CLI のエコシステム内で管理したい。
+We want to manage these declaratively while staying within the `gh` CLI ecosystem.
 
 ## Decision
 
-`.github/settings.yml` にリポジトリ設定を YAML で記述し、`gh-infra`（`babarot/gh-infra`）拡張で適用する。
+Describe repository settings in YAML in `.github/settings.yml` and apply them with `gh-infra` (`babarot/gh-infra`).
 
-- `scripts/100-gh-extensions.sh` で `gh extension install babarot/gh-infra` を実行
-- `gh infra plan` で差分を確認してから `gh infra apply` で反映
-- ステートファイルを持たず、GitHub の現在状態を信頼できる情報源とする
+- Run `gh extension install babarot/gh-infra` in `scripts/100-gh-extensions.sh`
+- Review the diff with `gh infra plan` before applying it with `gh infra apply`
+- Do not maintain a state file; treat GitHub's current state as the source of truth
 
 ## Alternatives Considered
 
 ### Terraform GitHub Provider
 
-検討した — GitHub-as-Code の定番だが、プロバイダのインストール・HCL・ステートファイル・ステートロックが必要で、個人リポジトリにはオーバーヘッドが大きい。
+Considered — it is a standard choice for GitHub-as-Code, but it requires provider installation, HCL, state files, and state locking, which is too much overhead for a personal repository.
 
-### Probot Settings / GitHub App 系
+### Probot Settings / GitHub App approaches
 
-不採用 — GitHub App やサーバーの運用が必要で、`plan` による事前プレビューがなく即時適用される。
+Not adopted — they require operating a GitHub App or server, and they apply changes immediately without a `plan` preview.
 
-### Web UI で手動管理（現状維持）
+### Manual management in the Web UI (status quo)
 
-不採用 — バージョン管理・再現性・変更履歴が得られず、本 ADR の動機を満たさない。
+Not adopted — it provides no version control, reproducibility, or change history, so it does not satisfy the motivation of this ADR.
 
 ## Consequences
 
-- `.github/settings.yml` がリポジトリ設定の信頼できる情報源になる
-- `gh-infra` 拡張のインストールが前提になる（`scripts/100-gh-extensions.sh` で自動化）
-- 設定変更は `plan` → `apply` のフローで適用し、差分をレビューできる
-- デフォルトブランチに `required_linear_history` / `required_signatures` を強制するため、マージコミットや未署名コミットはプッシュできない
-- 運用方法は [reference/gh-infra.md](../../reference/gh-infra.md) に記載
+- `.github/settings.yml` becomes the source of truth for repository settings
+- Installing the `gh-infra` extension becomes a prerequisite (automated in `scripts/100-gh-extensions.sh`)
+- Configuration changes follow the `plan` → `apply` flow so the diff can be reviewed
+- Because `required_linear_history` / `required_signatures` are enforced on the default branch, merge commits and unsigned commits cannot be pushed
+- Operational guidance is documented in [reference/gh-infra.md](../../reference/gh-infra.md)

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -8,13 +8,13 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 
 ## ADR List
 
-| ID                                   | Title                                          | Status   |
-| ------------------------------------ | ---------------------------------------------- | -------- |
+| ID                                   | Title                                                   | Status   |
+| ------------------------------------ | ------------------------------------------------------- | -------- |
 | [0001](./0001-json-install-map.md)   | Adopt a JSON mapping table for symbolic link management | Accepted |
-| [0002](./0002-ssh-commit-signing.md) | Adopt SSH commit signing                       | Accepted |
-| [0003](./0003-sheldon-starship.md)   | Replace Oh-My-Zsh with Sheldon + Starship      | Accepted |
-| [0004](./0004-gh-q.md)               | Replace ghq with gh-q                          | Accepted |
-| [0005](./0005-gh-infra.md)           | Manage repository settings declaratively with gh-infra | Accepted |
+| [0002](./0002-ssh-commit-signing.md) | Adopt SSH commit signing                                | Accepted |
+| [0003](./0003-sheldon-starship.md)   | Replace Oh-My-Zsh with Sheldon + Starship               | Accepted |
+| [0004](./0004-gh-q.md)               | Replace ghq with gh-q                                   | Accepted |
+| [0005](./0005-gh-infra.md)           | Manage repository settings declaratively with gh-infra  | Accepted |
 
 ## How to Write a New ADR
 
@@ -51,4 +51,4 @@ Write what was adopted and how it will be operated.
 ```
 
 > [!TIP]
-> Record the reasons for rejecting alternatives in detail. AI assistants lose context between sessions, so ADRs become the only way to recover *why* a particular choice was made.
+> Record the reasons for rejecting alternatives in detail. AI assistants lose context between sessions, so ADRs become the only way to recover _why_ a particular choice was made.

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -1,29 +1,29 @@
 # ADR
 
-dotfiles の技術選定に関する意思決定記録です。
+This page records decisions about technical choices in dotfiles.
 
-## ADR とは
+## What is an ADR?
 
-ADR（Architecture Decision Record）は、技術選定に関する重要な意思決定を、背景・判断・影響まで含めて記録するための文書です。
+An ADR (Architecture Decision Record) is a document for recording important technical decisions, including the background, the decision itself, and its impact.
 
-## ADR 一覧
+## ADR List
 
-| ID                                   | タイトル                                       | Status   |
+| ID                                   | Title                                          | Status   |
 | ------------------------------------ | ---------------------------------------------- | -------- |
-| [0001](./0001-json-install-map.md)   | シンボリックリンク管理に JSON 対応表を採用     | Accepted |
-| [0002](./0002-ssh-commit-signing.md) | SSH コミット署名の採用                         | Accepted |
-| [0003](./0003-sheldon-starship.md)   | Sheldon + Starship による Oh-My-Zsh の置き換え | Accepted |
-| [0004](./0004-gh-q.md)               | gh-q による ghq の置き換え                     | Accepted |
-| [0005](./0005-gh-infra.md)           | gh-infra による宣言的リポジトリ設定管理        | Accepted |
+| [0001](./0001-json-install-map.md)   | Adopt a JSON mapping table for symbolic link management | Accepted |
+| [0002](./0002-ssh-commit-signing.md) | Adopt SSH commit signing                       | Accepted |
+| [0003](./0003-sheldon-starship.md)   | Replace Oh-My-Zsh with Sheldon + Starship      | Accepted |
+| [0004](./0004-gh-q.md)               | Replace ghq with gh-q                          | Accepted |
+| [0005](./0005-gh-infra.md)           | Manage repository settings declaratively with gh-infra | Accepted |
 
-## 新しい ADR の書き方
+## How to Write a New ADR
 
-連番付きファイル名で作成し、以下の構成を使います。
+Create it with a sequentially numbered file name and use the following structure.
 
 ```md
-# XXXX: 決定のタイトル
+# XXXX: Decision Title
 
-その決定が何を扱うのかを 1 行で要約
+A one-line summary of what the decision covers
 
 ## Status
 
@@ -31,24 +31,24 @@ Proposed / Accepted / Superseded / Deprecated
 
 ## Context
 
-この決定が必要になった背景、課題、制約を書く。
+Write the background, problems, and constraints that made this decision necessary.
 
 ## Decision
 
-何を採用したか、どのように運用するかを書く。
+Write what was adopted and how it will be operated.
 
 ## Alternatives Considered
 
-### 選択肢 A
+### Option A
 
-- 概要
-- 採用しなかった理由
+- Summary
+- Why it was not adopted
 
 ## Consequences
 
-- 得られる利点
-- 受け入れる制約
+- Benefits gained
+- Constraints accepted
 ```
 
 > [!TIP]
-> 代替案を不採用とした理由は詳細に記録してください。AI アシスタントはセッション間でコンテキストを失うため、ADR が「なぜその選択をしたのか」を再取得する唯一の手段になります。
+> Record the reasons for rejecting alternatives in detail. AI assistants lose context between sessions, so ADRs become the only way to recover *why* a particular choice was made.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -2,19 +2,19 @@
 sidebar_position: 0
 ---
 
-# 🛠️ 開発者向けガイド
+# 🛠️ Developer Guide
 
-dotfiles リポジトリ自体を変更・拡張するための開発者向けドキュメントです。
+This is the developer documentation for changing and extending the dotfiles repository itself.
 
-## How-to ガイド
+## How-to Guides
 
-- [リポジトリ構成](./01-project-structure.md) — ディレクトリ構造と各ファイルの役割
-- [ドキュメントスタイル](./02-docs-style.md) — Markdown 執筆規約
+- [Project Structure](./01-project-structure.md) — Directory structure and the role of each file
+- [Documentation Style](./02-docs-style.md) — Markdown writing conventions
 
-## 設計と意思決定
+## Design and Decisions
 
-- [意思決定記録（ADR）](./99-adr/README.md) — 技術選定の意思決定記録
+- [Decision Records (ADR)](./99-adr/README.md) — Records of technical decision-making
 
-## 更新方針
+## Update Policy
 
-設定ファイル、スクリプト、ツール構成を変えたときは、このセクションと `docs/reference/` の関連ページも同じ変更で更新してください。
+When you change configuration files, scripts, or the tool setup, update this section and the related pages under `docs/reference/` in the same change as well.

--- a/docs/guides/01-quick-start.md
+++ b/docs/guides/01-quick-start.md
@@ -1,52 +1,52 @@
-# クイックスタート
+# Quick Start
 
-新しいマシン（または Codespaces）で開発環境を再現する最短手順です。
+This is the shortest procedure for reproducing the development environment on a new machine (or in Codespaces).
 
-このガイドを終えると、シェル設定・エディタ (Neovim)・ターミナル (Ghostty)・各種 CLI ツールがすべて揃った状態になります。
+By the end of this guide, your shell configuration, editor (Neovim), terminal (Ghostty), and various CLI tools will all be set up.
 
-## 1. リポジトリをクローンする
+## 1. Clone the repository
 
 ```bash
 git clone https://github.com/daiksud/dotfiles.git ~/.dotfiles
 cd ~/.dotfiles
 ```
 
-## 2. インストールスクリプトを実行する
+## 2. Run the installation script
 
 ```bash
 bash install.sh
 ```
 
-このスクリプトが行うこと:
+What this script does:
 
-1. `install_map.json` に従ってシンボリックリンクを作成
-2. Homebrew をインストール（未導入の場合）
-3. `Brewfile` のパッケージをインストール
-4. 各セットアップスクリプト (`scripts/`) を実行
+1. Creates symbolic links according to `install_map.json`
+2. Installs Homebrew if it is not already installed
+3. Installs the packages listed in `Brewfile`
+4. Runs each setup script in `scripts/`
 
-## 3. シェルを再起動する
+## 3. Restart the shell
 
 ```bash
 exec zsh
 ```
 
-Starship プロンプトが表示されれば成功です。
+If the Starship prompt appears, the setup was successful.
 
-## 動作確認
+## Verification
 
 ```bash
-# Neovim が起動するか
+# Check whether Neovim starts
 nvim --version
 
-# mise でツールバージョンが管理されているか
+# Check whether tool versions are managed by mise
 mise list
 
-# gh CLI が認証済みか
+# Check whether gh CLI is authenticated
 gh auth status
 ```
 
-## 次のステップ
+## Next steps
 
-- [インストール詳細](./02-installation.md) — `install.sh` の詳しい動作を知る
-- [リンクの追加・変更](./03-managing-links.md) — 新しい設定ファイルを管理対象に加える
-- [Git ID の自動切り替え](./04-git-identity.md) — 複数 GitHub アカウントを使い分ける
+- [Installation details](./02-installation.md) — Learn how `install.sh` works in detail
+- [Adding and changing links](./03-managing-links.md) — Add a new configuration file to the managed set
+- [Automatic Git ID switching](./04-git-identity.md) — Use multiple GitHub accounts

--- a/docs/guides/02-installation.md
+++ b/docs/guides/02-installation.md
@@ -1,67 +1,67 @@
-# インストール
+# Installation
 
-`install.sh` の動作と実行方法を説明します。
+This page explains how `install.sh` works and how to run it.
 
-## 前提条件
+## Prerequisites
 
-| プラットフォーム    | 必要なもの                                                        |
-| ------------------- | ----------------------------------------------------------------- |
-| macOS               | 特になし（`git` と `python3` はシステム標準で利用可能）           |
-| Ubuntu (Codespaces) | `build-essential`, `git`（`000-codespace.sh` が自動インストール） |
+| Platform            | Requirements                                                       |
+| ------------------- | ------------------------------------------------------------------ |
+| macOS               | None in particular (`git` and `python3` are available by default) |
+| Ubuntu (Codespaces) | `build-essential`, `git` (`000-codespace.sh` installs them automatically) |
 
-## 実行方法
+## How to run
 
 ```bash
 cd ~/.dotfiles
 bash install.sh
 ```
 
-## 処理の流れ
+## Processing flow
 
-`install.sh` は以下の順序で処理を行います。
+`install.sh` performs the following steps in order.
 
 ```mermaid
 graph TD
-    A[install_map.json を読み込み] --> B[シンボリックリンク作成]
-    B --> C[scripts/000-*.sh 実行]
-    C --> D[scripts/001-*.sh 実行<br/>Homebrew インストール]
-    D --> E[scripts/002-*.sh 実行<br/>Brewfile パッケージ]
-    E --> F[scripts/100-*.sh 実行<br/>各ツール設定]
-    F --> G[allowed_signers 生成]
+    A[Read `install_map.json`] --> B[Create symbolic links]
+    B --> C[Run `scripts/000-*.sh`]
+    C --> D[Run `scripts/001-*.sh`<br/>Install Homebrew]
+    D --> E[Run `scripts/002-*.sh`<br/>Brewfile packages]
+    E --> F[Run `scripts/100-*.sh`<br/>Configure each tool]
+    F --> G[Generate `allowed_signers`]
 ```
 
-### 1. シンボリックリンク作成
+### 1. Create symbolic links
 
-`install_map.json` を Python3 でパースし、各エントリについて:
+It parses `install_map.json` with Python3 and, for each entry:
 
-1. 宛先の親ディレクトリが存在しなければ `mkdir -p` で作成
-2. 親ディレクトリがシンボリックリンクの場合は実ディレクトリに変換（旧環境からの移行対応）
-3. 既存のファイル/リンクがあれば削除
-4. `dotfiles/<source>` → `<target>` のシンボリックリンクを作成
+1. Creates the destination parent directory with `mkdir -p` if it does not exist
+2. If the parent directory is a symbolic link, converts it to a real directory (to support migration from older environments)
+3. Removes any existing file or link
+4. Creates a symbolic link from `dotfiles/<source>` to `<target>`
 
-### 2. セットアップスクリプト実行
+### 2. Run setup scripts
 
-`scripts/` 以下のスクリプトをファイル名順に実行します。
+It runs the scripts under `scripts/` in filename order.
 
-| スクリプト         | 内容                                                                 |
+| Script             | Description                                                          |
 | ------------------ | -------------------------------------------------------------------- |
-| `000-codespace.sh` | Ubuntu 固有の初期設定（タイムゾーン、デフォルトシェル）              |
-| `001-homebrew.sh`  | Homebrew のインストールと gcc 更新                                   |
-| `002-brewfile.sh`  | `Brewfile` に定義されたパッケージのインストール                      |
-| `100-*.sh`         | 各ツール個別の設定（Ghostty, LazyVim, sheldon, mise, tmux, gh 拡張） |
+| `000-codespace.sh` | Ubuntu-specific initial setup (time zone, default shell)            |
+| `001-homebrew.sh`  | Installs Homebrew and updates gcc                                   |
+| `002-brewfile.sh`  | Installs the packages defined in `Brewfile`                         |
+| `100-*.sh`         | Per-tool setup (Ghostty, LazyVim, sheldon, mise, tmux, gh extension) |
 
-`100-*` スクリプトのうち Homebrew に依存するもの（`ghostty`, `lazyvim`, `sheldon`）は逐次実行、それ以外は並列実行されます（最大並列数: `DOTFILES_PARALLEL_JOBS` 環境変数、デフォルト 3）。
+Among the `100-*` scripts, those that depend on Homebrew (`ghostty`, `lazyvim`, `sheldon`) run sequentially, while the others run in parallel (maximum concurrency: the `DOTFILES_PARALLEL_JOBS` environment variable, default `3`).
 
-### 3. SSH allowed_signers 生成
+### 3. Generate SSH `allowed_signers`
 
-グローバル `user.email` と `~/.ssh/id_ed25519.pub` が存在する場合、Git の SSH 署名検証用 `~/.ssh/allowed_signers` を生成します。
+If global `user.email` and `~/.ssh/id_ed25519.pub` exist, it generates `~/.ssh/allowed_signers` for Git SSH signature verification.
 
-## 再実行
+## Re-running
 
-`install.sh` は冪等です。何度実行しても同じ状態に収束します。既存のシンボリックリンクは削除してから再作成されます。
+`install.sh` is idempotent. No matter how many times you run it, it converges to the same state. Existing symbolic links are removed and then recreated.
 
-## 環境変数
+## Environment variables
 
-| 変数                     | デフォルト | 説明                           |
-| ------------------------ | ---------- | ------------------------------ |
-| `DOTFILES_PARALLEL_JOBS` | `3`        | `100-*` スクリプトの並列実行数 |
+| Variable                 | Default | Description                          |
+| ------------------------ | ------- | ------------------------------------ |
+| `DOTFILES_PARALLEL_JOBS` | `3`     | Number of parallel `100-*` scripts |

--- a/docs/guides/02-installation.md
+++ b/docs/guides/02-installation.md
@@ -4,9 +4,9 @@ This page explains how `install.sh` works and how to run it.
 
 ## Prerequisites
 
-| Platform            | Requirements                                                       |
-| ------------------- | ------------------------------------------------------------------ |
-| macOS               | None in particular (`git` and `python3` are available by default) |
+| Platform            | Requirements                                                              |
+| ------------------- | ------------------------------------------------------------------------- |
+| macOS               | None in particular (`git` and `python3` are available by default)         |
 | Ubuntu (Codespaces) | `build-essential`, `git` (`000-codespace.sh` installs them automatically) |
 
 ## How to run
@@ -45,9 +45,9 @@ It runs the scripts under `scripts/` in filename order.
 
 | Script             | Description                                                          |
 | ------------------ | -------------------------------------------------------------------- |
-| `000-codespace.sh` | Ubuntu-specific initial setup (time zone, default shell)            |
-| `001-homebrew.sh`  | Installs Homebrew and updates gcc                                   |
-| `002-brewfile.sh`  | Installs the packages defined in `Brewfile`                         |
+| `000-codespace.sh` | Ubuntu-specific initial setup (time zone, default shell)             |
+| `001-homebrew.sh`  | Installs Homebrew and updates gcc                                    |
+| `002-brewfile.sh`  | Installs the packages defined in `Brewfile`                          |
 | `100-*.sh`         | Per-tool setup (Ghostty, LazyVim, sheldon, mise, tmux, gh extension) |
 
 Among the `100-*` scripts, those that depend on Homebrew (`ghostty`, `lazyvim`, `sheldon`) run sequentially, while the others run in parallel (maximum concurrency: the `DOTFILES_PARALLEL_JOBS` environment variable, default `3`).
@@ -62,6 +62,6 @@ If global `user.email` and `~/.ssh/id_ed25519.pub` exist, it generates `~/.ssh/a
 
 ## Environment variables
 
-| Variable                 | Default | Description                          |
-| ------------------------ | ------- | ------------------------------------ |
+| Variable                 | Default | Description                        |
+| ------------------------ | ------- | ---------------------------------- |
 | `DOTFILES_PARALLEL_JOBS` | `3`     | Number of parallel `100-*` scripts |

--- a/docs/guides/03-managing-links.md
+++ b/docs/guides/03-managing-links.md
@@ -13,9 +13,9 @@ This page explains how to manage symbolic link mappings by editing `install_map.
 }
 ```
 
-| Field      | Description                                                      |
-| ---------- | ---------------------------------------------------------------- |
-| `<source>` | File or directory name inside the `dotfiles/` directory         |
+| Field      | Description                                                   |
+| ---------- | ------------------------------------------------------------- |
+| `<source>` | File or directory name inside the `dotfiles/` directory       |
 | `<target>` | Absolute destination path (`~` expands to the home directory) |
 
 ## Add a link

--- a/docs/guides/03-managing-links.md
+++ b/docs/guides/03-managing-links.md
@@ -1,8 +1,8 @@
-# リンクの追加・変更
+# Adding and changing links
 
-`install_map.json` を編集して、シンボリックリンクの対応関係を管理する方法を説明します。
+This page explains how to manage symbolic link mappings by editing `install_map.json`.
 
-## install_map.json の形式
+## `install_map.json` format
 
 ```json
 {
@@ -13,22 +13,22 @@
 }
 ```
 
-| フィールド | 説明                                                       |
-| ---------- | ---------------------------------------------------------- |
-| `<source>` | `dotfiles/` ディレクトリ内のファイルまたはディレクトリ名   |
-| `<target>` | リンク先の絶対パス（`~` はホームディレクトリに展開される） |
+| Field      | Description                                                      |
+| ---------- | ---------------------------------------------------------------- |
+| `<source>` | File or directory name inside the `dotfiles/` directory         |
+| `<target>` | Absolute destination path (`~` expands to the home directory) |
 
-## リンクを追加する
+## Add a link
 
-### 例: Copilot skills を管理する
+### Example: manage Copilot skills
 
-1. 設定ファイルを `dotfiles/` に配置する:
+1. Place the configuration files in `dotfiles/`:
 
 ```bash
 cp -r ~/.copilot/skills dotfiles/skills
 ```
 
-2. `install_map.json` にエントリを追加する:
+2. Add an entry to `install_map.json`:
 
 ```json
 {
@@ -38,13 +38,13 @@ cp -r ~/.copilot/skills dotfiles/skills
 }
 ```
 
-3. `install.sh` を再実行する:
+3. Re-run `install.sh`:
 
 ```bash
 bash install.sh
 ```
 
-### 例: ~/.config 以下のアプリを追加する
+### Example: add an application under `~/.config`
 
 ```bash
 cp -r ~/.config/lazygit dotfiles/lazygit
@@ -58,15 +58,15 @@ cp -r ~/.config/lazygit dotfiles/lazygit
 }
 ```
 
-## リンクを削除する
+## Remove a link
 
-`install_map.json` から該当エントリを削除し、必要に応じて `dotfiles/` 内のファイルも削除します。
+Remove the relevant entry from `install_map.json`, and remove the file in `dotfiles/` as needed.
 
 > [!NOTE]
-> `install.sh` はエントリにないリンクを自動削除しません。既存のシンボリックリンクは手動で `rm` してください。
+> `install.sh` does not automatically remove links that are no longer in the entries. Remove existing symbolic links manually with `rm`.
 
-## 宛先の親ディレクトリについて
+## About destination parent directories
 
-`install.sh` は宛先の親ディレクトリを自動作成します（`mkdir -p`）。`~/.config/` が存在しなくても問題ありません。
+`install.sh` automatically creates the destination parent directory (`mkdir -p`). It is fine if `~/.config/` does not already exist.
 
-旧環境で `~/.config` がシンボリックリンクだった場合は、実ディレクトリに変換してから内容を移行します。
+If `~/.config` was a symbolic link in an older environment, it converts it to a real directory first and then migrates the contents.

--- a/docs/guides/04-git-identity.md
+++ b/docs/guides/04-git-identity.md
@@ -1,70 +1,70 @@
-# Git ID の自動切り替え
+# Automatic Git ID switching
 
-リポジトリごとに GitHub アカウント（`user.name`, `user.email`, SSH 署名鍵）を自動で切り替える仕組みを説明します。
+This page explains the mechanism that automatically switches the GitHub account (`user.name`, `user.email`, SSH signing key) for each repository.
 
-## 仕組み
+## How it works
 
-`zsh/gh-config-dir.zsh` が zsh の `chpwd` フックに登録されており、ディレクトリ移動のたびに以下を実行します:
+`zsh/gh-config-dir.zsh` is registered in the zsh `chpwd` hook, and every time you change directories it performs the following:
 
 ```mermaid
 graph TD
-    A[cd でディレクトリ移動] --> B{Git リポジトリ内?}
-    B -- No --> U[GH_CONFIG_DIR を unset]
-    B -- Yes --> D[GH_CONFIG_DIR を .git/gh に設定]
+    A[Move directories with `cd`] --> B{Inside a Git repository?}
+    B -- No --> U[Unset `GH_CONFIG_DIR`]
+    B -- Yes --> D[Set `GH_CONFIG_DIR` to `.git/gh`]
     D --> C{GitHub origin?}
-    C -- No --> T[gh auth token を取得]
-    C -- Yes --> E{ローカル user.name/email が設定済み?}
-    E -- Yes --> F[SSH 署名鍵だけ同期]
-    E -- No --> G[gh API で identity 取得]
-    G --> H[git config --local に設定]
+    C -- No --> T[Get `gh auth token`]
+    C -- Yes --> E{Is local `user.name`/`user.email` already set?}
+    E -- Yes --> F[Sync only the SSH signing key]
+    E -- No --> G[Get identity with `gh api`]
+    G --> H[Set values in `git config --local`]
     H --> F
     F --> T
     U --> T
-    T -- 成功 --> V[COPILOT_GITHUB_TOKEN を設定]
-    T -- 失敗 --> W[COPILOT_GITHUB_TOKEN を unset]
+    T -- Success --> V[Set `COPILOT_GITHUB_TOKEN`]
+    T -- Failure --> W[Unset `COPILOT_GITHUB_TOKEN`]
 ```
 
-## 前提条件
+## Prerequisites
 
-- `gh auth login` で認証済みであること
-- `gh` コマンドが `PATH` から実行できること
-- SSH 鍵が `~/.ssh/<github-login>.pub` に配置されていること
-- Copilot CLI (`copilot`) がインストール済みであること（Copilot CLI 切り替えを使う場合）
+- You must already be authenticated with `gh auth login`
+- The `gh` command must be executable from `PATH`
+- Your SSH public key must be placed at `~/.ssh/<github-login>.pub`
+- Copilot CLI (`copilot`) must already be installed (if you use Copilot CLI switching)
 
-## 動作の詳細
+## Detailed behavior
 
-### GH_CONFIG_DIR
+### `GH_CONFIG_DIR`
 
-すべての Git リポジトリで `.git/gh/` ディレクトリを作成し、`GH_CONFIG_DIR` 環境変数に設定します。これにより `gh` コマンドの認証情報がリポジトリ単位で分離されます。GitHub origin でないリポジトリでも `GH_CONFIG_DIR` は設定されますが、identity 同期（以下）は実行されません。
+It creates a `.git/gh/` directory in every Git repository and sets the `GH_CONFIG_DIR` environment variable to it. This isolates `gh` authentication data per repository. `GH_CONFIG_DIR` is also set for repositories whose origin is not GitHub, but identity synchronization (below) does not run for them.
 
-### Git identity の自動設定
+### Automatic Git identity configuration
 
-1. `gh api user` で現在のアカウントの `login`, `name` を取得
-2. `gh api user/emails` で primary email を取得
-3. `git config --local user.name` / `user.email` に設定
+1. Gets the current account's `login` and `name` with `gh api user`
+2. Gets the primary email with `gh api user/emails`
+3. Sets them in `git config --local user.name` / `user.email`
 
-### SSH 署名鍵の自動設定
+### Automatic SSH signing key configuration
 
-1. `~/.ssh/<login>.pub` を `user.signingkey` に設定
-2. `commit.gpgsign = true`, `gpg.format = ssh` をローカルに設定
-3. `~/.ssh/allowed_signers` を更新（署名検証用）
+1. Sets `~/.ssh/<login>.pub` as `user.signingkey`
+2. Sets `commit.gpgsign = true` and `gpg.format = ssh` locally
+3. Updates `~/.ssh/allowed_signers` (for signature verification)
 
-### Copilot CLI アカウントの自動切り替え
+### Automatic Copilot CLI account switching
 
-`GH_CONFIG_DIR` を更新した後、`gh auth token` でトークンを取得して `COPILOT_GITHUB_TOKEN` に設定します。Copilot CLI はこの環境変数を保存済み認証情報より優先するため、`gh` と同じアカウントが使われます。
+After updating `GH_CONFIG_DIR`, it gets a token with `gh auth token` and sets it in `COPILOT_GITHUB_TOKEN`. Copilot CLI gives this environment variable higher priority than stored credentials, so it uses the same account as `gh`.
 
-| 状況 | `GH_CONFIG_DIR` | `COPILOT_GITHUB_TOKEN` |
+| Situation | `GH_CONFIG_DIR` | `COPILOT_GITHUB_TOKEN` |
 | ---- | --------------- | ---------------------- |
-| 作業用リポジトリ（認証済み） | `.git/gh` | 作業アカウントのトークン |
-| 個人リポジトリ（認証済み） | `.git/gh` | 個人アカウントのトークン |
-| `gh` 未ログインのリポジトリ | `.git/gh` | unset（保存済みにフォールバック） |
-| git リポジトリ外 | unset | グローバル `gh` アカウントのトークン |
+| Work repository (authenticated) | `.git/gh` | Work account token |
+| Personal repository (authenticated) | `.git/gh` | Personal account token |
+| Repository where `gh` is not logged in | `.git/gh` | unset (falls back to stored credentials) |
+| Outside a Git repository | unset | Global `gh` account token |
 
-## グローバル .gitconfig との関係
+## Relationship with global `.gitconfig`
 
-グローバル `~/.gitconfig` には `user.name` / `user.email` / `user.signingkey` を設定しません。すべてリポジトリローカルで管理するため、アカウントの混在を防げます。
+The global `~/.gitconfig` does not set `user.name`, `user.email`, or `user.signingkey`. Because everything is managed locally per repository, you can avoid mixing accounts.
 
-グローバルには以下のような共通設定のみを記述します:
+Only shared settings like the following are written globally:
 
 - `push.autosetupremote = true`
 - `push.default = current`
@@ -76,39 +76,39 @@ graph TD
 - `core.quotepath = false`
 - `init.defaultBranch = main`
 
-`user.signingkey` もグローバルには設定しません。リポジトリ単位で適切な鍵が自動設定されます。
+`user.signingkey` is also not set globally. The appropriate key is configured automatically for each repository.
 
-## トラブルシューティング
+## Troubleshooting
 
-### identity が設定されない
+### Identity is not configured
 
 ```bash
-# gh の認証状態を確認
+# Check gh authentication status
 gh auth status
 
-# email スコープが必要な場合
+# If the email scope is required
 gh auth refresh -h github.com -s user:email
 ```
 
-### 署名鍵が見つからない
+### Signing key cannot be found
 
-SSH 鍵のファイル名が `~/.ssh/<github-login>.pub` になっているか確認してください。
+Make sure the SSH key filename is `~/.ssh/<github-login>.pub`.
 
 ```bash
 ls ~/.ssh/*.pub
 gh api user --jq '.login'
 ```
 
-### Copilot CLI のアカウントが切り替わらない
+### Copilot CLI account does not switch
 
-`COPILOT_GITHUB_TOKEN` が正しく設定されているか確認します。
+Check whether `COPILOT_GITHUB_TOKEN` is set correctly.
 
 ```bash
-# 現在の Copilot トークンの有無を確認
+# Check whether the current Copilot token is present
 echo $COPILOT_GITHUB_TOKEN | cut -c1-10
 
-# gh の認証状態を確認（GH_CONFIG_DIR が設定されていればリポジトリ固有の状態）
+# Check gh authentication status (repository-specific if GH_CONFIG_DIR is set)
 gh auth status
 ```
 
-トークンが空の場合、そのリポジトリで `gh auth login` を実行してください。
+If the token is empty, run `gh auth login` in that repository.

--- a/docs/guides/04-git-identity.md
+++ b/docs/guides/04-git-identity.md
@@ -53,12 +53,12 @@ It creates a `.git/gh/` directory in every Git repository and sets the `GH_CONFI
 
 After updating `GH_CONFIG_DIR`, it gets a token with `gh auth token` and sets it in `COPILOT_GITHUB_TOKEN`. Copilot CLI gives this environment variable higher priority than stored credentials, so it uses the same account as `gh`.
 
-| Situation | `GH_CONFIG_DIR` | `COPILOT_GITHUB_TOKEN` |
-| ---- | --------------- | ---------------------- |
-| Work repository (authenticated) | `.git/gh` | Work account token |
-| Personal repository (authenticated) | `.git/gh` | Personal account token |
-| Repository where `gh` is not logged in | `.git/gh` | unset (falls back to stored credentials) |
-| Outside a Git repository | unset | Global `gh` account token |
+| Situation                              | `GH_CONFIG_DIR` | `COPILOT_GITHUB_TOKEN`                   |
+| -------------------------------------- | --------------- | ---------------------------------------- |
+| Work repository (authenticated)        | `.git/gh`       | Work account token                       |
+| Personal repository (authenticated)    | `.git/gh`       | Personal account token                   |
+| Repository where `gh` is not logged in | `.git/gh`       | unset (falls back to stored credentials) |
+| Outside a Git repository               | unset           | Global `gh` account token                |
 
 ## Relationship with global `.gitconfig`
 

--- a/docs/guides/05-concept.md
+++ b/docs/guides/05-concept.md
@@ -1,49 +1,49 @@
-# コンセプト
+# Concept
 
-この dotfiles リポジトリの設計思想と方針を説明します。
+This page explains the design philosophy and policies of this dotfiles repository.
 
-## ワンコマンドで完結する再現性
+## One-command reproducibility
 
-新しいマシンでも `bash install.sh` の 1 コマンドだけで、シェル・エディタ・ターミナル・CLI ツールがすべて揃った状態を再現できることを最優先にしている。
+The highest priority is being able to reproduce a fully prepared environment—shell, editor, terminal, and CLI tools—on a new machine with a single command: `bash install.sh`.
 
-手動の設定手順やインストール後の追加作業を極力排除し、スクリプトに落とし込む。
+It eliminates manual setup steps and post-installation work as much as possible by turning them into scripts.
 
-## 宣言的な設定管理
+## Declarative configuration management
 
-- **シンボリックリンク** — `install_map.json` で source → target を宣言
-- **パッケージ** — `Brewfile` で必要なツールを宣言
-- **プラグイン** — `plugins.toml`（sheldon）で Zsh プラグインを宣言
-- **ランタイム** — `config.toml`（mise）で言語バージョンを宣言
+- **Symbolic links** — Declare source → target in `install_map.json`
+- **Packages** — Declare required tools in `Brewfile`
+- **Plugins** — Declare Zsh plugins in `plugins.toml` (sheldon)
+- **Runtimes** — Declare language versions in `config.toml` (mise)
 
-「何を入れるか」はすべて設定ファイルに書かれており、スクリプトは「設定ファイルを適用する」だけ。
+Everything about "what to install" is written in configuration files, and the scripts only "apply the configuration files."
 
-## テーマは Tokyo Night Storm で統一
+## Use Tokyo Night Storm consistently as the theme
 
-すべてのツールのカラースキームを **Tokyo Night Storm** に統一している。
+All tools use **Tokyo Night Storm** as the unified color scheme.
 
-| ツール   | 設定                                                   |
-| -------- | ------------------------------------------------------ |
-| Ghostty  | `theme = TokyoNight Storm`                             |
-| Neovim   | `tokyonight.nvim` (style = `"storm"`, transparent)     |
-| tmux     | `tokyo-night-tmux` (theme = `storm`)                   |
-| Starship | Tokyo Night Storm の配色に合わせたカスタムフォーマット |
+| Tool     | Configuration                                             |
+| -------- | --------------------------------------------------------- |
+| Ghostty  | `theme = TokyoNight Storm`                                |
+| Neovim   | `tokyonight.nvim` (style = `"storm"`, transparent)        |
+| tmux     | `tokyo-night-tmux` (theme = `storm`)                      |
+| Starship | Custom formatting matched to the Tokyo Night Storm palette |
 
-ターミナル → tmux → エディタ間で色の断絶がなく、視覚的に一貫した環境になる。
+This creates a visually consistent environment without color discontinuities between the terminal, tmux, and editor.
 
-## マルチアカウント対応
+## Multi-account support
 
-GitHub アカウントを複数使い分ける前提で設計している。
+It is designed on the assumption that you use multiple GitHub accounts.
 
-- `GH_CONFIG_DIR` をリポジトリ単位で分離
-- `user.name` / `user.email` / `user.signingkey` はグローバルに設定しない
-- `cd` するだけで適切なアカウントに自動切り替え
+- Separate `GH_CONFIG_DIR` per repository
+- Do not set `user.name` / `user.email` / `user.signingkey` globally
+- Automatically switch to the appropriate account just by using `cd`
 
-## 最小限の外部依存
+## Minimal external dependencies
 
-- シェルフレームワーク（Oh-My-Zsh 等）に依存しない
-- 各ツールの責務を分離し、単一障害点を作らない
-- macOS と Ubuntu (Codespaces) の両方で動作する
+- Does not depend on shell frameworks (such as Oh-My-Zsh)
+- Separates each tool's responsibility to avoid creating a single point of failure
+- Works on both macOS and Ubuntu (Codespaces)
 
-## 冪等性
+## Idempotency
 
-`install.sh` は何度実行しても同じ結果に収束する。途中で失敗しても再実行すれば正しい状態になる。
+`install.sh` converges to the same result no matter how many times you run it. Even if it fails partway through, re-running it restores the correct state.

--- a/docs/guides/05-concept.md
+++ b/docs/guides/05-concept.md
@@ -21,11 +21,11 @@ Everything about "what to install" is written in configuration files, and the sc
 
 All tools use **Tokyo Night Storm** as the unified color scheme.
 
-| Tool     | Configuration                                             |
-| -------- | --------------------------------------------------------- |
-| Ghostty  | `theme = TokyoNight Storm`                                |
-| Neovim   | `tokyonight.nvim` (style = `"storm"`, transparent)        |
-| tmux     | `tokyo-night-tmux` (theme = `storm`)                      |
+| Tool     | Configuration                                              |
+| -------- | ---------------------------------------------------------- |
+| Ghostty  | `theme = TokyoNight Storm`                                 |
+| Neovim   | `tokyonight.nvim` (style = `"storm"`, transparent)         |
+| tmux     | `tokyo-night-tmux` (theme = `storm`)                       |
 | Starship | Custom formatting matched to the Tokyo Night Storm palette |
 
 This creates a visually consistent environment without color discontinuities between the terminal, tmux, and editor.

--- a/docs/guides/06-skills.md
+++ b/docs/guides/06-skills.md
@@ -9,9 +9,9 @@ This is a guide for getting started quickly with custom Copilot CLI skills.
 
 ## Available skills
 
-| Skill       | What it does                                                      |
-| ----------- | ----------------------------------------------------------------- |
-| `pr-create` | Automatically creates a draft PR from the current changes         |
+| Skill       | What it does                                                                        |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `pr-create` | Automatically creates a draft PR from the current changes                           |
 | `pr-fix`    | Fixes CI errors, handles reviews, and resolves merge conflicts for the specified PR |
 
 ## Use `pr-create`

--- a/docs/guides/06-skills.md
+++ b/docs/guides/06-skills.md
@@ -1,90 +1,90 @@
-# スキルの使い方
+# Using skills
 
-Copilot CLI のカスタムスキルをすぐに使い始めるためのガイドです。
+This is a guide for getting started quickly with custom Copilot CLI skills.
 
-## 前提
+## Prerequisites
 
-- dotfiles がインストール済み（`install.sh` 実行済み）
-- GitHub Copilot CLI がインストール済み
+- dotfiles are already installed (`install.sh` has been run)
+- GitHub Copilot CLI is already installed
 
-## 使えるスキル
+## Available skills
 
-| スキル      | やること                                                           |
-| ----------- | ------------------------------------------------------------------ |
-| `pr-create` | 今の変更からドラフト PR を自動作成                                 |
-| `pr-fix`    | 指定した PR の CI エラー修正・レビュー対応・マージコンフリクト解消 |
+| Skill       | What it does                                                      |
+| ----------- | ----------------------------------------------------------------- |
+| `pr-create` | Automatically creates a draft PR from the current changes         |
+| `pr-fix`    | Fixes CI errors, handles reviews, and resolves merge conflicts for the specified PR |
 
-## pr-create を使う
+## Use `pr-create`
 
-変更をステージした状態で：
+With your changes staged:
 
 ```bash
 copilot -p "/pr-create"
 ```
 
-変更理由を伝えたい場合：
+If you want to explain the reason for the change:
 
 ```bash
-copilot -p "/pr-create 認証ロジックのリファクタリング、#42 に関連"
+copilot -p "/pr-create Refactor authentication logic, related to #42"
 ```
 
-インタラクティブセッションでは `/pr create` でも起動する（後述）。
+In an interactive session, you can also start it with `/pr create` (described later).
 
-### 何が起きるか
+### What happens
 
-1. 対応する Task (Issue) を確認（なければ作成を提案）
-2. 差分を読んでコミットメッセージを考える
-3. feature ブランチを作ってプッシュ
-4. ドラフト PR を作成
-5. あなたを Assignee に設定
+1. Checks for a corresponding Task (Issue) and suggests creating one if it does not exist
+2. Reads the diff and comes up with a commit message
+3. Creates and pushes a feature branch
+4. Creates a draft PR
+5. Sets you as the assignee
 
-## pr-fix を使う
+## Use `pr-fix`
 
 ```bash
 copilot -p "/pr-fix PR #42"
 ```
 
-インタラクティブセッションでは `/pr fix` でも起動する（後述）。
+In an interactive session, you can also start it with `/pr fix` (described later).
 
-### 何が起きるか
+### What happens
 
-1. マージコンフリクトを検出して解消
-2. CI の失敗をログから特定して修正（通るまで繰り返し）
-3. レビューコメントを確認し、妥当なものは修正
-4. ローカルレビューを実施してからプッシュ
-5. 各レビューコメントに対応内容をリプライし、スレッドを resolve
+1. Detects and resolves merge conflicts
+2. Identifies CI failures from logs and fixes them (repeating until they pass)
+3. Checks review comments and applies reasonable fixes
+4. Performs a local review before pushing
+5. Replies to each review comment with what was addressed and resolves the thread
 
-モード指定も可能:
+You can also specify a mode:
 
 ```bash
-copilot -p "/pr-fix ci #42"        # CI 失敗のみ
-copilot -p "/pr-fix feedback #42"  # レビューコメントのみ
-copilot -p "/pr-fix conflicts #42" # コンフリクトのみ
+copilot -p "/pr-fix ci #42"        # CI failures only
+copilot -p "/pr-fix feedback #42"  # Review comments only
+copilot -p "/pr-fix conflicts #42" # Conflicts only
 ```
 
-## /pr create・/pr fix との統合
+## Integration with `/pr create` and `/pr fix`
 
-`install.sh` によって `dotfiles/copilot-instructions.md` が `~/.copilot/copilot-instructions.md` へシンボリックリンクされる。
-このファイルには以下の指示が含まれており、インタラクティブセッションで常時ロードされる:
+`install.sh` creates a symbolic link from `dotfiles/copilot-instructions.md` to `~/.copilot/copilot-instructions.md`.
+This file contains the following instructions and is always loaded in interactive sessions:
 
-- `/pr create` が呼ばれたら → `pr-create` スキルを使う
-- `/pr fix` が呼ばれたら → `pr-fix` スキルを使う
+- When `/pr create` is invoked → use the `pr-create` skill
+- When `/pr fix` is invoked → use the `pr-fix` skill
 
-これにより、ビルトインの `/pr` サブコマンドを使っても、定義済みスキルの手順に従った動作になる。
+As a result, even when you use the built-in `/pr` subcommand, it behaves according to the procedure defined in the skills.
 
 > [!NOTE]
-> この統合は Copilot の instruction 読み込みを介した仕組みであり、完全に確定的なバインディングではない。スキルを確実に使わせたい場合は `/pr-create` や `/pr-fix` で直接呼び出すこと。
+> This integration works through Copilot instruction loading and is not a completely deterministic binding. If you want to ensure the skill is used, invoke it directly with `/pr-create` or `/pr-fix`.
 
-## エイリアス設定（おすすめ）
+## Alias setup (recommended)
 
-`.zshrc` や `.bashrc` に追加：
+Add the following to `.zshrc` or `.bashrc`:
 
 ```bash
 alias pr-create='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-create skill $*"; }; f'
 alias pr-fix='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-fix skill $*"; }; f'
 ```
 
-使い方：
+Usage:
 
 ```bash
 pr-create

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -2,17 +2,17 @@
 sidebar_position: 0
 ---
 
-# 📖 ガイド
+# 📖 Guides
 
-dotfiles のセットアップから日常的な使い方までをまとめたガイド集です。
+A collection of guides covering everything from setting up these dotfiles to everyday usage.
 
-## まず試す
+## Start here
 
-- [クイックスタート](./01-quick-start.md) — 新しいマシンで環境を再現する最短手順
+- [Quick Start](./01-quick-start.md) — The shortest path to reproducing the environment on a new machine
 
-## 使い方ガイド
+## Usage guides
 
-- [インストール](./02-installation.md) — `install.sh` の動作と実行方法
-- [リンクの追加・変更](./03-managing-links.md) — `install_map.json` の編集方法
-- [Git ID の自動切り替え](./04-git-identity.md) — マルチアカウント運用
-- [コンセプト](./05-concept.md) — 設計思想と方針
+- [Installation](./02-installation.md) — How `install.sh` works and how to run it
+- [Adding and changing links](./03-managing-links.md) — How to edit `install_map.json`
+- [Automatic Git ID switching](./04-git-identity.md) — Multi-account workflows
+- [Concept](./05-concept.md) — Design philosophy and policies

--- a/docs/issues/issue-1.md
+++ b/docs/issues/issue-1.md
@@ -1,18 +1,18 @@
-# Issue 1: サイトタイトルを daiksud/dotfiles に変更
+# Issue 1: Change the site title to daiksud/dotfiles
 
-## 日付
+## Date
 
 2026-05-27
 
-## 背景・目的
+## Background and purpose
 
-GitHub Pages のサイトタイトルが `dotfiles` のみだと、他のユーザーの dotfiles リポジトリと区別がつかない。`daiksud/dotfiles` とすることでリポジトリを一意に識別できるようにする。
+If the GitHub Pages site title is only `dotfiles`, it cannot be distinguished from other users' dotfiles repositories. Changing it to `daiksud/dotfiles` makes the repository uniquely identifiable.
 
-## 変更内容
+## Changes
 
-- `.docusaurus/docusaurus.config.ts` の `title`（サイト全体）を `daiksud/dotfiles` に変更
-- 同ファイルの `navbar.title` も `daiksud/dotfiles` に変更
+- Change `title` (site-wide) in `.docusaurus/docusaurus.config.ts` to `daiksud/dotfiles`
+- Change `navbar.title` in the same file to `daiksud/dotfiles`
 
-## 備考
+## Notes
 
-なし
+None

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -2,32 +2,32 @@
 sidebar_position: 0
 ---
 
-# 📋 リファレンス
+# 📋 Reference
 
-dotfiles の設定ファイル・ツール一覧・構造の詳細リファレンスです。
+a detailed reference for the dotfiles configuration files, tool list, and structure.
 
-## ツール別設定
+## Tool-specific settings
 
-- [Ghostty](./ghostty.md) — ターミナルエミュレータ
-- [Git](./git.md) — グローバル Git 設定
-- [mise](./mise.md) — 開発ツールバージョン管理
-- [Neovim](./nvim.md) — エディタ（LazyVim）
-- [RTK](./rtk.md) — LLM トークン削減 CLI プロキシ
-- [Sheldon](./sheldon.md) — Zsh プラグインマネージャ
-- [Starship](./starship.md) — プロンプト
-- [tmux](./tmux.md) — ターミナルマルチプレクサ
-- [Zsh](./zsh/README.md) — シェル設定
-  - [カスタムプラグイン](./zsh/plugins.md) — `zsh/` 配下の関数群
+- [Ghostty](./ghostty.md) — Terminal emulator
+- [Git](./git.md) — Global Git settings
+- [mise](./mise.md) — Development tool version management
+- [Neovim](./nvim.md) — Editor (LazyVim)
+- [RTK](./rtk.md) — CLI proxy for reducing LLM token usage
+- [Sheldon](./sheldon.md) — Zsh plugin manager
+- [Starship](./starship.md) — Prompt
+- [tmux](./tmux.md) — Terminal multiplexer
+- [Zsh](./zsh/README.md) — Shell configuration
+  - [Custom plugins](./zsh/plugins.md) — Functions under `zsh/`
 
-## インフラ
+## Infrastructure
 
-- [gh-infra](./gh-infra.md) — `.github/settings.yml` による宣言的リポジトリ設定管理
-- [install_map.json](./install-map.md) — シンボリックリンク対応表の仕様
-- [スクリプト一覧](./scripts.md) — `scripts/` 以下の各スクリプトの役割
-- [ツール一覧](./tools.md) — Brewfile で管理するツールとその用途
+- [gh-infra](./gh-infra.md) — Declarative repository settings management with `.github/settings.yml`
+- [install_map.json](./install-map.md) — Specification for the symbolic link mapping table
+- [Script list](./scripts.md) — The role of each script under `scripts/`
+- [Tool list](./tools.md) — Tools managed in the Brewfile and their purposes
 
-## 使い分け
+## When to use what
 
-- 使い方を知りたいときは [ガイド](../guides/README.md)
-- 各ファイルの正確な仕様を確認したいときは **リファレンス**（このセクション）
-- リポジトリの構造を変更したいときは [開発者向けガイド](../development/README.md)
+- If you want to learn how to use things, see the [guides](../guides/README.md)
+- If you want to check the exact specification of each file, use the **Reference** section (this section)
+- If you want to change the repository structure, see the [developer guide](../development/README.md)

--- a/docs/reference/gh-infra.md
+++ b/docs/reference/gh-infra.md
@@ -1,85 +1,85 @@
 # gh-infra
 
-`.github/settings.yml` による宣言的なリポジトリ設定管理のリファレンスです。
+This is the reference for declarative repository settings management with `.github/settings.yml`.
 
-## 概要
+## Overview
 
-[gh-infra](https://github.com/babarot/gh-infra)（`babarot/gh-infra`）は、GitHub リポジトリの設定を YAML で宣言的に管理する GitHub CLI 拡張です。Terraform に似ていますが、ステートファイルは不要で、GitHub 自体が信頼できる情報源になります。
+[gh-infra](https://github.com/babarot/gh-infra) (`babarot/gh-infra`) is a GitHub CLI extension for declaratively managing GitHub repository settings in YAML. It is similar to Terraform, but does not require a state file because GitHub itself serves as the source of truth.
 
-このリポジトリでは、ラベル・マージ戦略・ブランチ保護（ruleset）・セキュリティ設定などを `.github/settings.yml` に記述し、UI を手動操作せずに再現可能な形で管理します。
+In this repository, labels, merge strategies, branch protection (rulesets), security settings, and more are described in `.github/settings.yml` and managed in a reproducible form without manually operating the UI.
 
-## ファイル
+## File
 
-`.github/settings.yml`（シンボリックリンクはせず、リポジトリ内に直接配置）
+`.github/settings.yml` (placed directly in the repository, not as a symbolic link)
 
-## 主要な設定
+## Key settings
 
-`.github/settings.yml` の `spec` で定義している主な項目です。
+These are the main items defined under `spec` in `.github/settings.yml`.
 
-| セクション       | 内容                                                                                   |
-| ---------------- | -------------------------------------------------------------------------------------- |
-| `labels`         | Issue / PR ラベルの定義（名前・説明・色）                                               |
-| `features`       | issues / projects / wiki / discussions / pull_requests の有効・無効                    |
-| `merge_strategy` | squash マージのみ許可、auto-merge とマージ後のブランチ自動削除を有効化                  |
-| `security`       | 脆弱性アラート・自動セキュリティ修正・プライベート脆弱性報告を有効化                    |
-| `rulesets`       | デフォルトブランチの保護（後述）                                                        |
-| `actions`        | GitHub Actions の許可範囲とデフォルトの `workflow_permissions`                          |
+| Section          | Contents                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------- |
+| `labels`         | Definitions for Issue / PR labels (name, description, color)                            |
+| `features`       | Enable / disable `issues`, `projects`, `wiki`, `discussions`, and `pull_requests`      |
+| `merge_strategy` | Allow only squash merges, and enable auto-merge and automatic branch deletion after merge |
+| `security`       | Enable vulnerability alerts, automated security fixes, and private vulnerability reporting |
+| `rulesets`       | Protection for the default branch (described below)                                     |
+| `actions`        | Allowed scope for GitHub Actions and default `workflow_permissions`                     |
 
-### デフォルトブランチの ruleset
+### Default branch ruleset
 
-`rulesets` でデフォルトブランチに以下を強制しています。
+The following are enforced on the default branch through `rulesets`.
 
-| ルール                     | 値      | 説明                                       |
-| -------------------------- | ------- | ------------------------------------------ |
-| `required_linear_history`  | `true`  | マージコミットを禁止（直線的な履歴を強制） |
-| `required_signatures`      | `true`  | 署名付きコミットを必須化                   |
-| `non_fast_forward`         | `true`  | 強制プッシュを禁止                         |
-| `deletion`                 | `true`  | ブランチ削除を禁止                         |
-| `creation`                 | `false` | ブランチ作成の制限はしない                 |
+| Rule                       | Value   | Description                                     |
+| -------------------------- | ------- | ----------------------------------------------- |
+| `required_linear_history`  | `true`  | Disallow merge commits (enforce linear history) |
+| `required_signatures`      | `true`  | Require signed commits                          |
+| `non_fast_forward`         | `true`  | Disallow force pushes                           |
+| `deletion`                 | `true`  | Disallow branch deletion                        |
+| `creation`                 | `false` | Do not restrict branch creation                 |
 
 > [!IMPORTANT]
-> `required_linear_history` が有効なため、デフォルトブランチにはマージコミットをプッシュできません。ローカルで取り込む場合は fast-forward マージ（`git merge --ff-only`）を使用してください。
+> Because `required_linear_history` is enabled, you cannot push merge commits to the default branch. When integrating changes locally, use a fast-forward merge (`git merge --ff-only`).
 
-## セットアップ
+## Setup
 
-`gh-infra` 拡張は `scripts/100-gh-extensions.sh` で自動インストールされます（[スクリプト一覧](./scripts.md) を参照）。手動でインストールする場合:
+The `gh-infra` extension is installed automatically by `scripts/100-gh-extensions.sh` (see [Script list](./scripts.md)). To install it manually:
 
 ```bash
 gh extension install babarot/gh-infra
 ```
 
-## 使い方
+## Usage
 
-`plan` で差分を確認してから `apply` で適用します。`.github/settings.yml` を明示的に指定します。
+Review the diff with `plan`, then apply it with `apply`. Specify `.github/settings.yml` explicitly.
 
 ```bash
-# YAML と現在の GitHub 設定の差分を表示
+# Show the diff between the YAML and the current GitHub settings
 gh infra plan .github/settings.yml
 
-# 差分を適用（確認プロンプトあり）
+# Apply the diff (with confirmation prompt)
 gh infra apply .github/settings.yml
 
-# YAML の構文・スキーマを検証
+# Validate the YAML syntax and schema
 gh infra validate .github/settings.yml
 ```
 
-既存リポジトリの設定を YAML として書き出す場合は `import` を使います。
+Use `import` to export the settings of an existing repository as YAML.
 
 ```bash
 gh infra import daiksud/dotfiles > .github/settings.yml
 ```
 
-## コマンド一覧
+## Command list
 
-| コマンド          | 説明                                       |
-| ----------------- | ------------------------------------------ |
-| `plan [path]`     | YAML と現在の GitHub 設定の差分を表示       |
-| `apply [path]`    | 差分を適用（確認プロンプトあり）           |
-| `import <repo>`   | 既存リポジトリの設定を YAML として書き出す |
-| `validate [path]` | YAML の構文・スキーマを検証                 |
+| Command           | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| `plan [path]`     | Show the diff between the YAML and the current GitHub settings |
+| `apply [path]`    | Apply the diff (with confirmation prompt)                  |
+| `import <repo>`   | Export the settings of an existing repository as YAML      |
+| `validate [path]` | Validate the YAML syntax and schema                        |
 
-## 参考
+## References
 
-- [gh-infra リポジトリ](https://github.com/babarot/gh-infra)
-- [gh-infra ドキュメント](https://babarot.github.io/gh-infra/introduction/getting-started/)
-- 技術選定の背景は [ADR 0005](../development/99-adr/0005-gh-infra.md) を参照
+- [gh-infra repository](https://github.com/babarot/gh-infra)
+- [gh-infra documentation](https://babarot.github.io/gh-infra/introduction/getting-started/)
+- For the background behind this technology choice, see [ADR 0005](../development/99-adr/0005-gh-infra.md)

--- a/docs/reference/gh-infra.md
+++ b/docs/reference/gh-infra.md
@@ -16,26 +16,26 @@ In this repository, labels, merge strategies, branch protection (rulesets), secu
 
 These are the main items defined under `spec` in `.github/settings.yml`.
 
-| Section          | Contents                                                                                |
-| ---------------- | --------------------------------------------------------------------------------------- |
-| `labels`         | Definitions for Issue / PR labels (name, description, color)                            |
-| `features`       | Enable / disable `issues`, `projects`, `wiki`, `discussions`, and `pull_requests`      |
-| `merge_strategy` | Allow only squash merges, and enable auto-merge and automatic branch deletion after merge |
+| Section          | Contents                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| `labels`         | Definitions for Issue / PR labels (name, description, color)                               |
+| `features`       | Enable / disable `issues`, `projects`, `wiki`, `discussions`, and `pull_requests`          |
+| `merge_strategy` | Allow only squash merges, and enable auto-merge and automatic branch deletion after merge  |
 | `security`       | Enable vulnerability alerts, automated security fixes, and private vulnerability reporting |
-| `rulesets`       | Protection for the default branch (described below)                                     |
-| `actions`        | Allowed scope for GitHub Actions and default `workflow_permissions`                     |
+| `rulesets`       | Protection for the default branch (described below)                                        |
+| `actions`        | Allowed scope for GitHub Actions and default `workflow_permissions`                        |
 
 ### Default branch ruleset
 
 The following are enforced on the default branch through `rulesets`.
 
-| Rule                       | Value   | Description                                     |
-| -------------------------- | ------- | ----------------------------------------------- |
-| `required_linear_history`  | `true`  | Disallow merge commits (enforce linear history) |
-| `required_signatures`      | `true`  | Require signed commits                          |
-| `non_fast_forward`         | `true`  | Disallow force pushes                           |
-| `deletion`                 | `true`  | Disallow branch deletion                        |
-| `creation`                 | `false` | Do not restrict branch creation                 |
+| Rule                      | Value   | Description                                     |
+| ------------------------- | ------- | ----------------------------------------------- |
+| `required_linear_history` | `true`  | Disallow merge commits (enforce linear history) |
+| `required_signatures`     | `true`  | Require signed commits                          |
+| `non_fast_forward`        | `true`  | Disallow force pushes                           |
+| `deletion`                | `true`  | Disallow branch deletion                        |
+| `creation`                | `false` | Do not restrict branch creation                 |
 
 > [!IMPORTANT]
 > Because `required_linear_history` is enabled, you cannot push merge commits to the default branch. When integrating changes locally, use a fast-forward merge (`git merge --ff-only`).
@@ -71,12 +71,12 @@ gh infra import daiksud/dotfiles > .github/settings.yml
 
 ## Command list
 
-| Command           | Description                                                |
-| ----------------- | ---------------------------------------------------------- |
+| Command           | Description                                                    |
+| ----------------- | -------------------------------------------------------------- |
 | `plan [path]`     | Show the diff between the YAML and the current GitHub settings |
-| `apply [path]`    | Apply the diff (with confirmation prompt)                  |
-| `import <repo>`   | Export the settings of an existing repository as YAML      |
-| `validate [path]` | Validate the YAML syntax and schema                        |
+| `apply [path]`    | Apply the diff (with confirmation prompt)                      |
+| `import <repo>`   | Export the settings of an existing repository as YAML          |
+| `validate [path]` | Validate the YAML syntax and schema                            |
 
 ## References
 

--- a/docs/reference/ghostty.md
+++ b/docs/reference/ghostty.md
@@ -1,59 +1,59 @@
 # Ghostty
 
-Ghostty ターミナルエミュレータの設定ファイルリファレンスです。
+This is the reference for the Ghostty terminal emulator configuration files.
 
-## ファイル
+## File
 
 `dotfiles/ghostty/config` → `~/.config/ghostty/config`
 
-## 設定一覧
+## Settings list
 
-### 外観
+### Appearance
 
-| 設定                        | 値                       | 説明               |
-| --------------------------- | ------------------------ | ------------------ |
-| `theme`                     | `TokyoNight Storm`       | カラースキーム     |
-| `font-family`               | `Moralerspace Neon HW`   | フォント           |
-| `font-size`                 | `13.5`                   | フォントサイズ     |
-| `background-image`          | `hololive-en-advent.jpg` | 背景画像           |
-| `background-image-fit`      | `cover`                  | 画像のフィット方法 |
-| `background-image-opacity`  | `0.06`                   | 背景画像の透過率   |
-| `background-image-position` | `center`                 | 画像の配置         |
+| Setting                      | Value                    | Description        |
+| ---------------------------- | ------------------------ | ------------------ |
+| `theme`                      | `TokyoNight Storm`       | Color scheme       |
+| `font-family`                | `Moralerspace Neon HW`   | Font               |
+| `font-size`                  | `13.5`                   | Font size          |
+| `background-image`           | `hololive-en-advent.jpg` | Background image   |
+| `background-image-fit`       | `cover`                  | Image fit method   |
+| `background-image-opacity`   | `0.06`                   | Background opacity |
+| `background-image-position`  | `center`                 | Image placement    |
 
-### ウィンドウ
+### Window
 
-| 設定                               | 値                        | 説明                                             |
-| ---------------------------------- | ------------------------- | ------------------------------------------------ |
-| `fullscreen`                       | `non-native-visible-menu` | フルスクリーンモード                             |
-| `macos-non-native-fullscreen`      | `visible-menu`            | macOS 非ネイティブフルスクリーン                 |
-| `macos-titlebar-style`             | `hidden`                  | タイトルバーを非表示                             |
-| `window-inherit-working-directory` | `false`                   | 新ウィンドウでカレントディレクトリを引き継がない |
-| `window-padding-y`                 | `0`                       | 垂直パディング                                   |
+| Setting                             | Value                     | Description                                         |
+| ----------------------------------- | ------------------------- | --------------------------------------------------- |
+| `fullscreen`                        | `non-native-visible-menu` | Fullscreen mode                                     |
+| `macos-non-native-fullscreen`       | `visible-menu`            | macOS non-native fullscreen                         |
+| `macos-titlebar-style`              | `hidden`                  | Hide the title bar                                  |
+| `window-inherit-working-directory`  | `false`                   | Do not inherit the current directory in new windows |
+| `window-padding-y`                  | `0`                       | Vertical padding                                    |
 
-### 入力
+### Input
 
-| 設定                      | 値     | 説明                                 |
-| ------------------------- | ------ | ------------------------------------ |
-| `macos-option-as-alt`     | `true` | Option キーを Alt として使用         |
-| `mouse-hide-while-typing` | `true` | タイピング中にマウスカーソルを非表示 |
+| Setting                    | Value  | Description                        |
+| -------------------------- | ------ | ---------------------------------- |
+| `macos-option-as-alt`      | `true` | Use the Option key as Alt          |
+| `mouse-hide-while-typing`  | `true` | Hide the mouse cursor while typing |
 
-### 無効化したキーバインド
+### Disabled keybindings
 
-tmux でタブ・ペイン管理を行うため、Ghostty 組み込みのタブ・スプリット系キーバインドをすべて無効化している。
+To manage tabs and panes with tmux, all built-in Ghostty keybindings related to tabs and splits are disabled.
 
-**タブ系:**
+**Tab-related:**
 
-- `⌘T` (新規タブ)
-- `⌘⇧[` / `⌘⇧]` (タブ切り替え)
-- `⌘1` 〜 `⌘9` (タブ番号ジャンプ)
+- `⌘T` (new tab)
+- `⌘⇧[` / `⌘⇧]` (switch tabs)
+- `⌘1` through `⌘9` (jump to tab number)
 
-**スプリット系:**
+**Split-related:**
 
-- `⌘D` / `⌘⇧D` (分割)
-- `⌘⌥↑↓←→` (ペインリサイズ)
-- `⌘⌃↑↓←→` (ペイン移動)
-- `⌘⇧Enter` (ペイン追加)
+- `⌘D` / `⌘⇧D` (split)
+- `⌘⌥↑↓←→` (resize pane)
+- `⌘⌃↑↓←→` (move pane)
+- `⌘⇧Enter` (add pane)
 
-## 背景画像
+## Background image
 
-`dotfiles/ghostty/hololive-en-advent.jpg` が設定ディレクトリに含まれており、シンボリックリンク経由で配置される。
+`dotfiles/ghostty/hololive-en-advent.jpg` is included in the configuration directory and placed via a symbolic link.

--- a/docs/reference/ghostty.md
+++ b/docs/reference/ghostty.md
@@ -10,32 +10,32 @@ This is the reference for the Ghostty terminal emulator configuration files.
 
 ### Appearance
 
-| Setting                      | Value                    | Description        |
-| ---------------------------- | ------------------------ | ------------------ |
-| `theme`                      | `TokyoNight Storm`       | Color scheme       |
-| `font-family`                | `Moralerspace Neon HW`   | Font               |
-| `font-size`                  | `13.5`                   | Font size          |
-| `background-image`           | `hololive-en-advent.jpg` | Background image   |
-| `background-image-fit`       | `cover`                  | Image fit method   |
-| `background-image-opacity`   | `0.06`                   | Background opacity |
-| `background-image-position`  | `center`                 | Image placement    |
+| Setting                     | Value                    | Description        |
+| --------------------------- | ------------------------ | ------------------ |
+| `theme`                     | `TokyoNight Storm`       | Color scheme       |
+| `font-family`               | `Moralerspace Neon HW`   | Font               |
+| `font-size`                 | `13.5`                   | Font size          |
+| `background-image`          | `hololive-en-advent.jpg` | Background image   |
+| `background-image-fit`      | `cover`                  | Image fit method   |
+| `background-image-opacity`  | `0.06`                   | Background opacity |
+| `background-image-position` | `center`                 | Image placement    |
 
 ### Window
 
-| Setting                             | Value                     | Description                                         |
-| ----------------------------------- | ------------------------- | --------------------------------------------------- |
-| `fullscreen`                        | `non-native-visible-menu` | Fullscreen mode                                     |
-| `macos-non-native-fullscreen`       | `visible-menu`            | macOS non-native fullscreen                         |
-| `macos-titlebar-style`              | `hidden`                  | Hide the title bar                                  |
-| `window-inherit-working-directory`  | `false`                   | Do not inherit the current directory in new windows |
-| `window-padding-y`                  | `0`                       | Vertical padding                                    |
+| Setting                            | Value                     | Description                                         |
+| ---------------------------------- | ------------------------- | --------------------------------------------------- |
+| `fullscreen`                       | `non-native-visible-menu` | Fullscreen mode                                     |
+| `macos-non-native-fullscreen`      | `visible-menu`            | macOS non-native fullscreen                         |
+| `macos-titlebar-style`             | `hidden`                  | Hide the title bar                                  |
+| `window-inherit-working-directory` | `false`                   | Do not inherit the current directory in new windows |
+| `window-padding-y`                 | `0`                       | Vertical padding                                    |
 
 ### Input
 
-| Setting                    | Value  | Description                        |
-| -------------------------- | ------ | ---------------------------------- |
-| `macos-option-as-alt`      | `true` | Use the Option key as Alt          |
-| `mouse-hide-while-typing`  | `true` | Hide the mouse cursor while typing |
+| Setting                   | Value  | Description                        |
+| ------------------------- | ------ | ---------------------------------- |
+| `macos-option-as-alt`     | `true` | Use the Option key as Alt          |
+| `mouse-hide-while-typing` | `true` | Hide the mouse cursor while typing |
 
 ### Disabled keybindings
 

--- a/docs/reference/git.md
+++ b/docs/reference/git.md
@@ -1,41 +1,41 @@
 # Git
 
-グローバル Git 設定（`~/.gitconfig`）のリファレンスです。
+This is the reference for the global Git configuration (`~/.gitconfig`).
 
-## ファイル
+## File
 
 `dotfiles/gitconfig` → `~/.gitconfig`
 
-## 設定一覧
+## Settings list
 
-| セクション    | キー                 | 値                       | 説明                                            |
-| ------------- | -------------------- | ------------------------ | ----------------------------------------------- |
-| `[push]`      | `autosetupremote`    | `true`                   | push 時にリモートトラッキングブランチを自動設定 |
-| `[push]`      | `default`            | `current`                | 同名のリモートブランチに push                   |
-| `[commit]`    | `gpgsign`            | `true`                   | すべてのコミットを自動署名                      |
-| `[core]`      | `quotepath`          | `false`                  | 日本語ファイル名をエスケープせず表示            |
-| `[gpg]`       | `format`             | `ssh`                    | 署名方式に SSH を使用                           |
-| `[gpg "ssh"]` | `allowedsignersfile` | `~/.ssh/allowed_signers` | 署名検証用の許可済み署名者ファイル              |
-| `[init]`      | `defaultbranch`      | `main`                   | 新規リポジトリのデフォルトブランチ名            |
-| `[pull]`      | `rebase`             | `true`                   | pull 時にマージではなくリベース                 |
-| `[rebase]`    | `autosquash`         | `true`                   | `fixup!` / `squash!` コミットを自動整理         |
+| Section       | Key                  | Value                    | Description                                          |
+| ------------- | -------------------- | ------------------------ | ---------------------------------------------------- |
+| `[push]`      | `autosetupremote`    | `true`                   | Automatically set the remote tracking branch on push |
+| `[push]`      | `default`            | `current`                | Push to the remote branch with the same name         |
+| `[commit]`    | `gpgsign`            | `true`                   | Automatically sign all commits                       |
+| `[core]`      | `quotepath`          | `false`                  | Display Japanese file names without escaping         |
+| `[gpg]`       | `format`             | `ssh`                    | Use SSH for signing                                  |
+| `[gpg "ssh"]` | `allowedsignersfile` | `~/.ssh/allowed_signers` | Allowed signers file for signature verification      |
+| `[init]`      | `defaultbranch`      | `main`                   | Default branch name for new repositories             |
+| `[pull]`      | `rebase`             | `true`                   | Rebase instead of merge on pull                      |
+| `[rebase]`    | `autosquash`         | `true`                   | Automatically arrange `fixup!` / `squash!` commits   |
 
-## 認証ヘルパー
+## Authentication helper
 
-`gh auth setup-git` 相当の設定として、GitHub と Gist の credential helper に `gh auth git-credential` を使います。
-`gh` は絶対パスではなく `PATH` から解決するため、インストール先に依存しません。
+As the equivalent of `gh auth setup-git`, `gh auth git-credential` is used as the credential helper for GitHub and Gist.
+`gh` is resolved from `PATH` rather than an absolute path, so it does not depend on the installation location.
 
-| 対象                      | helper                    |
+| Target                    | helper                    |
 | ------------------------- | ------------------------- |
 | `https://github.com`      | `!gh auth git-credential` |
 | `https://gist.github.com` | `!gh auth git-credential` |
 
-## グローバルに設定しないもの
+## What is not configured globally
 
-以下はリポジトリローカルで `gh-config-dir.zsh` が自動設定するため、グローバルには記述しない:
+The following are not written globally because `gh-config-dir.zsh` sets them automatically locally for each repository:
 
 - `user.name`
 - `user.email`
 - `user.signingkey`
 
-詳細は [Git ID の自動切り替え](../guides/04-git-identity.md) を参照。
+For details, see [Automatic Git identity switching](../guides/04-git-identity.md).

--- a/docs/reference/install-map.md
+++ b/docs/reference/install-map.md
@@ -1,12 +1,12 @@
 # install_map.json
 
-シンボリックリンクの対応表ファイルの仕様です。
+This is the specification for the symbolic link mapping file.
 
-## 場所
+## Location
 
-リポジトリルートの `install_map.json`
+`install_map.json` at the repository root
 
-## 形式
+## Format
 
 ```json
 {
@@ -16,45 +16,45 @@
 }
 ```
 
-## フィールド定義
+## Field definitions
 
 ### links
 
-シンボリックリンクのマッピングを定義するオブジェクトです。
+An object that defines symbolic link mappings.
 
-| キー       | 型     | 説明                                                           |
-| ---------- | ------ | -------------------------------------------------------------- |
-| `<source>` | string | `dotfiles/` ディレクトリ内のファイルまたはディレクトリの相対名 |
-| `<target>` | string | リンク先の絶対パス。`~` はホームディレクトリに展開される       |
+| Key        | Type   | Description                                                          |
+| ---------- | ------ | -------------------------------------------------------------------- |
+| `<source>` | string | Relative name of a file or directory under the `dotfiles/` directory |
+| `<target>` | string | Absolute destination path. `~` is expanded to the home directory     |
 
-## 現在のエントリ
+## Current entries
 
-| Source                    | Target                               | 内容                               |
-| ------------------------- | ------------------------------------ | ---------------------------------- |
-| `zshrc`                   | `~/.zshrc`                           | Zsh 設定ファイル                   |
-| `zsh`                     | `~/.zsh`                             | Zsh カスタムプラグインディレクトリ |
-| `tmux.conf`               | `~/.tmux.conf`                       | tmux 設定                          |
-| `gitconfig`               | `~/.gitconfig`                       | Git グローバル設定                 |
-| `ghostty`                 | `~/.config/ghostty`                  | Ghostty ターミナル設定             |
-| `mise`                    | `~/.config/mise`                     | mise ツールバージョン設定          |
-| `nvim`                    | `~/.config/nvim`                     | Neovim 設定 (LazyVim)              |
-| `sheldon`                 | `~/.config/sheldon`                  | sheldon プラグイン設定             |
-| `starship.toml`           | `~/.config/starship.toml`            | Starship プロンプト設定            |
-| `skills`                  | `~/.copilot/skills`                  | Copilot CLI カスタムスキル         |
-| `copilot-instructions.md` | `~/.copilot/copilot-instructions.md` | Copilot CLI パーソナル指示ファイル |
+| Source                    | Target                               | Contents                               |
+| ------------------------- | ------------------------------------ | -------------------------------------- |
+| `zshrc`                   | `~/.zshrc`                           | Zsh configuration file                 |
+| `zsh`                     | `~/.zsh`                             | Zsh custom plugin directory            |
+| `tmux.conf`               | `~/.tmux.conf`                       | tmux configuration                     |
+| `gitconfig`               | `~/.gitconfig`                       | Global Git configuration               |
+| `ghostty`                 | `~/.config/ghostty`                  | Ghostty terminal configuration         |
+| `mise`                    | `~/.config/mise`                     | mise tool version configuration        |
+| `nvim`                    | `~/.config/nvim`                     | Neovim configuration (LazyVim)         |
+| `sheldon`                 | `~/.config/sheldon`                  | sheldon plugin configuration           |
+| `starship.toml`           | `~/.config/starship.toml`            | Starship prompt configuration          |
+| `skills`                  | `~/.copilot/skills`                  | Copilot CLI custom skills              |
+| `copilot-instructions.md` | `~/.copilot/copilot-instructions.md` | Copilot CLI personal instructions file |
 
-## 処理の仕様
+## Processing specification
 
-`install.sh` が `install_map.json` を処理する際の動作:
+Behavior when `install.sh` processes `install_map.json`:
 
-1. Python3 の `json` モジュールでファイルをパース
-2. `~` を `$HOME` に展開
-3. 各エントリについて:
-   - 宛先の親ディレクトリがシンボリックリンクの場合、実ディレクトリに変換して内容を移行
-   - 親ディレクトリが存在しなければ `mkdir -p` で作成
-   - 既存のファイル/リンクがあれば `rm -rf` で削除
-   - `dotfiles/<source>` → `<target>` のシンボリックリンクを作成
+1. Parse the file with Python3's `json` module
+2. Expand `~` to `$HOME`
+3. For each entry:
+   - If the destination's parent directory is a symbolic link, convert it to a real directory and migrate the contents
+   - If the parent directory does not exist, create it with `mkdir -p`
+   - If an existing file/link is present, remove it with `rm -rf`
+   - Create a symbolic link from `dotfiles/<source>` to `<target>`
 
-## 制約
+## Constraints
 
-- JSON としてバリッドであること（末尾カンマ不可）
+- Must be valid JSON (no trailing commas)

--- a/docs/reference/mise.md
+++ b/docs/reference/mise.md
@@ -15,8 +15,8 @@ As a result, `~/.config/mise/config.toml` becomes a machine-specific file manage
 
 ### `[settings.github]`
 
-| Key                  | Value               | Description                                            |
-| -------------------- | ------------------- | ------------------------------------------------------ |
+| Key                  | Value             | Description                                             |
+| -------------------- | ----------------- | ------------------------------------------------------- |
 | `credential_command` | `"gh auth token"` | Use the `gh` authentication token for GitHub API access |
 
 ## Repository-local settings

--- a/docs/reference/mise.md
+++ b/docs/reference/mise.md
@@ -1,54 +1,53 @@
 # mise
 
-開発ツールバージョン管理（mise）の設定リファレンスです。
+This is the configuration reference for development tool version management with mise.
 
-## グローバル設定
+## Global settings
 
-グローバル設定（`~/.config/mise/config.toml`）は dotfiles では管理しません。セットアップ時に `scripts/100-mise.sh` が `mise settings` コマンドで自動的に設定します。
+The global settings (`~/.config/mise/config.toml`) are not managed in dotfiles. During setup, `scripts/100-mise.sh` configures them automatically with the `mise settings` command.
 
 ```bash
-# 100-mise.sh が実行するコマンド（冪等）
+# Command executed by 100-mise.sh (idempotent)
 mise settings set github.credential_command "gh auth token"
 ```
 
-これにより `~/.config/mise/config.toml` はマシンごとに mise が管理するファイルとなり、`mise use -g <tool>` で追加したプライベートツールなども自由に記述できます。
+As a result, `~/.config/mise/config.toml` becomes a machine-specific file managed by mise, and you can freely add entries such as private tools added with `mise use -g <tool>`.
 
 ### `[settings.github]`
 
-| キー                 | 値                | 説明                                            |
-| -------------------- | ----------------- | ----------------------------------------------- |
-| `credential_command` | `"gh auth token"` | GitHub API アクセスに `gh` の認証トークンを使用 |
+| Key                  | Value               | Description                                            |
+| -------------------- | ------------------- | ------------------------------------------------------ |
+| `credential_command` | `"gh auth token"` | Use the `gh` authentication token for GitHub API access |
 
-## リポジトリローカル設定
+## Repository-local settings
 
-### `mise.toml`（リポジトリルート）
+### `mise.toml` (repository root)
 
-dotfiles リポジトリ自体の開発環境を定義します。
+Defines the development environment for the dotfiles repository itself.
 
-| ツール | バージョン | 説明                                   |
-| ------ | ---------- | -------------------------------------- |
-| `bun`  | `latest`   | Bun ランタイム（ドキュメントビルド用） |
+| Tool  | Version  | Description                              |
+| ----- | -------- | ---------------------------------------- |
+| `bun` | `latest` | Bun runtime (for building documentation) |
 
-`[hooks]` セクションで `postinstall = "bun install --frozen-lockfile"` が設定されており、`mise install` 後に依存関係が自動インストールされます。
+The `[hooks]` section sets `postinstall = "bun install --frozen-lockfile"`, so dependencies are installed automatically after `mise install`.
 
-### `[settings]`（`mise.toml`）
+### `[settings]` (`mise.toml`)
 
-| キー           | 値     | 説明                                 |
-| -------------- | ------ | ------------------------------------ |
-| `lockfile`     | `true` | ロックファイルを生成（再現性のため） |
-| `experimental` | `true` | 実験的機能を有効化                   |
+| Key            | Value  | Description                               |
+| -------------- | ------ | ----------------------------------------- |
+| `lockfile`     | `true` | Generate a lockfile (for reproducibility) |
+| `experimental` | `true` | Enable experimental features              |
 
-## シェル統合
+## Shell integration
 
-`.zshrc` で `eval "$(mise activate zsh)"` により有効化。`cd` 時にプロジェクトの `.mise.toml` や `.tool-versions` に応じてツールバージョンが自動切り替わる。
+Enabled in `.zshrc` via `eval "$(mise activate zsh)"`. Tool versions switch automatically on `cd` according to the project's `.mise.toml` or `.tool-versions`.
 
-## ツールの追加
+## Adding tools
 
 ```bash
-# グローバルに追加（~/.config/mise/config.toml に書き込まれる）
+# Add globally (written to ~/.config/mise/config.toml)
 mise use -g python@latest
 
-# ツールバージョンを確認
+# Check tool versions
 mise ls --current
 ```
-

--- a/docs/reference/nvim.md
+++ b/docs/reference/nvim.md
@@ -1,64 +1,64 @@
 # Neovim
 
-Neovim（LazyVim）の設定リファレンスです。
+This is the configuration reference for Neovim (LazyVim).
 
-## ファイル
+## File
 
 `dotfiles/nvim/` → `~/.config/nvim/`
 
-## 構成
+## Structure
 
-LazyVim をベースに最小限のカスタマイズを行っている。
+Minimal customizations are applied on top of LazyVim.
 
 ```
 nvim/
-├── init.lua              # エントリポイント（config.lazy を require）
+├── init.lua              # Entry point (requires config.lazy)
 ├── lua/
 │   ├── config/
-│   │   ├── lazy.lua      # lazy.nvim ブートストラップと設定
-│   │   ├── options.lua   # 追加オプション（現在は空）
-│   │   ├── keymaps.lua   # カスタムキーマップ
-│   │   └── autocmds.lua  # 追加 autocmd（現在は空）
+│   │   ├── lazy.lua      # lazy.nvim bootstrap and configuration
+│   │   ├── options.lua   # Additional options (currently empty)
+│   │   ├── keymaps.lua   # Custom keymaps
+│   │   └── autocmds.lua  # Additional autocmds (currently empty)
 │   └── plugins/
-│       ├── example.lua   # LazyVim サンプル（無効化済み）
-│       └── tokyonight.lua # カラースキーム設定
-├── lazyvim.json          # LazyVim extras 設定
-└── stylua.toml           # Lua フォーマッタ設定
+│       ├── example.lua   # LazyVim sample (disabled)
+│       └── tokyonight.lua # Color scheme settings
+├── lazyvim.json          # LazyVim extras settings
+└── stylua.toml           # Lua formatter settings
 ```
 
 ## LazyVim Extras
 
-`lazyvim.json` で有効化している extras:
+Extras enabled in `lazyvim.json`:
 
-| Extra             | 説明                        |
+| Extra             | Description                 |
 | ----------------- | --------------------------- |
-| `ai.copilot`      | GitHub Copilot 補完         |
-| `editor.fzf`      | fzf ファイル検索            |
-| `lang.json`       | JSON LSP・ハイライト        |
-| `lang.toml`       | TOML LSP・ハイライト        |
+| `ai.copilot`      | GitHub Copilot completion   |
+| `editor.fzf`      | fzf file search             |
+| `lang.json`       | JSON LSP and highlighting   |
+| `lang.toml`       | TOML LSP and highlighting   |
 | `lang.typescript` | TypeScript / JavaScript LSP |
 | `lang.vue`        | Vue.js LSP                  |
-| `linting.eslint`  | ESLint 統合                 |
+| `linting.eslint`  | ESLint integration          |
 
-## カスタムキーマップ
+## Custom keymaps
 
-インサートモードで Emacs 風カーソル移動を追加:
+Adds Emacs-style cursor movement in insert mode:
 
-| キー  | 動作      |
-| ----- | --------- |
-| `C-a` | 行頭      |
-| `C-e` | 行末      |
-| `C-b` | 左        |
-| `C-f` | 右        |
-| `C-n` | 下        |
-| `C-p` | 上        |
-| `C-d` | Delete    |
-| `C-v` | Page Down |
-| `M-v` | Page Up   |
+| Key   | Action     |
+| ----- | ---------- |
+| `C-a` | Line start |
+| `C-e` | Line end   |
+| `C-b` | Left       |
+| `C-f` | Right      |
+| `C-n` | Down       |
+| `C-p` | Up         |
+| `C-d` | Delete     |
+| `C-v` | Page Down  |
+| `M-v` | Page Up    |
 
-## カラースキーム
+## Color scheme
 
-Tokyo Night Storm を透過モードで使用:
+Uses Tokyo Night Storm in transparent mode:
 
 ```lua
 {
@@ -74,19 +74,19 @@ Tokyo Night Storm を透過モードで使用:
 }
 ```
 
-## lazy.nvim 設定
+## lazy.nvim settings
 
-| 設定                  | 値                          | 説明                                     |
-| --------------------- | --------------------------- | ---------------------------------------- |
-| `defaults.lazy`       | `false`                     | カスタムプラグインは起動時にロード       |
-| `defaults.version`    | `false`                     | 常に最新の git commit を使用             |
-| `checker.enabled`     | `true`                      | プラグイン更新を定期チェック             |
-| `checker.notify`      | `false`                     | 更新通知を表示しない                     |
-| `install.colorscheme` | `["tokyonight", "habamax"]` | 初回インストール時のフォールバックテーマ |
+| Setting               | Value                          | Description                                  |
+| --------------------- | ------------------------------ | -------------------------------------------- |
+| `defaults.lazy`       | `false`                        | Load custom plugins at startup               |
+| `defaults.version`    | `false`                        | Always use the latest git commit             |
+| `checker.enabled`     | `true`                         | Periodically check for plugin updates        |
+| `checker.notify`      | `false`                        | Do not show update notifications             |
+| `install.colorscheme` | `["tokyonight", "habamax"]` | Fallback themes for the initial installation |
 
-### 無効化された rtp プラグイン
+### Disabled rtp plugins
 
-パフォーマンス最適化のため以下を無効化:
+The following are disabled for performance optimization:
 
 - `gzip`
 - `tarPlugin`

--- a/docs/reference/nvim.md
+++ b/docs/reference/nvim.md
@@ -76,12 +76,12 @@ Uses Tokyo Night Storm in transparent mode:
 
 ## lazy.nvim settings
 
-| Setting               | Value                          | Description                                  |
-| --------------------- | ------------------------------ | -------------------------------------------- |
-| `defaults.lazy`       | `false`                        | Load custom plugins at startup               |
-| `defaults.version`    | `false`                        | Always use the latest git commit             |
-| `checker.enabled`     | `true`                         | Periodically check for plugin updates        |
-| `checker.notify`      | `false`                        | Do not show update notifications             |
+| Setting               | Value                       | Description                                  |
+| --------------------- | --------------------------- | -------------------------------------------- |
+| `defaults.lazy`       | `false`                     | Load custom plugins at startup               |
+| `defaults.version`    | `false`                     | Always use the latest git commit             |
+| `checker.enabled`     | `true`                      | Periodically check for plugin updates        |
+| `checker.notify`      | `false`                     | Do not show update notifications             |
 | `install.colorscheme` | `["tokyonight", "habamax"]` | Fallback themes for the initial installation |
 
 ### Disabled rtp plugins

--- a/docs/reference/rtk.md
+++ b/docs/reference/rtk.md
@@ -4,9 +4,9 @@ RTK is a CLI proxy that filters and compresses shell command output to reduce th
 
 ## Files
 
-| dotfiles | Link destination |
-|---|---|
-| `dotfiles/copilot-hooks/rtk-rewrite.json` | `~/.copilot/hooks/rtk-rewrite.json` |
+| dotfiles                                                     | Link destination                     |
+| ------------------------------------------------------------ | ------------------------------------ |
+| `dotfiles/copilot-hooks/rtk-rewrite.json`                    | `~/.copilot/hooks/rtk-rewrite.json`  |
 | `dotfiles/copilot-instructions.md` (including the RTK block) | `~/.copilot/copilot-instructions.md` |
 
 ## Setup

--- a/docs/reference/rtk.md
+++ b/docs/reference/rtk.md
@@ -1,64 +1,64 @@
 # RTK
 
-RTK はシェルコマンドの出力をフィルタリング・圧縮し、LLM が消費するトークンを削減する CLI プロキシです。
+RTK is a CLI proxy that filters and compresses shell command output to reduce the number of tokens consumed by an LLM.
 
-## ファイル
+## Files
 
-| dotfiles | リンク先 |
+| dotfiles | Link destination |
 |---|---|
 | `dotfiles/copilot-hooks/rtk-rewrite.json` | `~/.copilot/hooks/rtk-rewrite.json` |
-| `dotfiles/copilot-instructions.md`（RTK ブロック含む） | `~/.copilot/copilot-instructions.md` |
+| `dotfiles/copilot-instructions.md` (including the RTK block) | `~/.copilot/copilot-instructions.md` |
 
-## セットアップ
+## Setup
 
-### インストール
+### Installation
 
 ```bash
 brew install rtk
 ```
 
-### GitHub Copilot 向けフック（グローバル）
+### Hook for GitHub Copilot (global)
 
 ```bash
 rtk init --global --copilot
 ```
 
-`~/.copilot/hooks/rtk-rewrite.json` と `~/.copilot/copilot-instructions.md` の RTK ブロックを生成します。
-このリポジトリでは hook ファイルを `dotfiles/copilot-hooks/rtk-rewrite.json` として管理し、`install.sh` でシンリンクを作成します。
+Generates `~/.copilot/hooks/rtk-rewrite.json` and the RTK block in `~/.copilot/copilot-instructions.md`.
+In this repository, the hook file is managed as `dotfiles/copilot-hooks/rtk-rewrite.json`, and `install.sh` creates the symlink.
 
-## 使い方
+## Usage
 
-コマンドの先頭に `rtk` を付けるだけです。
+Just add `rtk` to the beginning of a command.
 
 ```bash
-# 通常コマンドの代わりに使う
+# Use instead of the normal command
 rtk git status
 rtk git log -10
 rtk cargo test
 rtk docker ps
 ```
 
-フックが有効な場合、GitHub Copilot CLI は自動的に `rtk` 経由でコマンドを実行します（手動プレフィックス不要）。
+When the hook is enabled, GitHub Copilot CLI automatically runs commands through `rtk` (no manual prefix needed).
 
-## メタコマンド
+## Meta commands
 
 ```bash
-rtk gain              # トークン削減量のダッシュボード
-rtk gain --history    # コマンドごとの削減履歴
-rtk discover          # rtk 未使用コマンドの検出
-rtk proxy <cmd>       # フィルタリングなしで実行（使用量のみ記録）
-rtk init --show       # フックの状態確認
+rtk gain              # Dashboard for token reduction
+rtk gain --history    # Reduction history by command
+rtk discover          # Detect commands not using rtk
+rtk proxy <cmd>       # Run without filtering (record usage only)
+rtk init --show       # Check hook status
 ```
 
-## アンインストール
+## Uninstall
 
 ```bash
 rtk init --uninstall --global --copilot
 ```
 
-`~/.copilot/hooks/rtk-rewrite.json` と `copilot-instructions.md` の RTK ブロックのみ削除します。他のファイルには影響しません。
+This removes only `~/.copilot/hooks/rtk-rewrite.json` and the RTK block in `copilot-instructions.md`. Other files are unaffected.
 
-## 参考
+## References
 
-- [RTK 公式サイト](https://www.rtk-ai.app/)
-- [GitHub Copilot 向け設定](https://www.rtk-ai.app/docs/getting-started/supported-agents/#github-copilot-vs-code-chat--cli)
+- [RTK official site](https://www.rtk-ai.app/)
+- [Configuration for GitHub Copilot](https://www.rtk-ai.app/docs/getting-started/supported-agents/#github-copilot-vs-code-chat--cli)

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -1,101 +1,101 @@
-# スクリプト一覧
+# Script list
 
-`scripts/` 以下のセットアップスクリプトの役割と実行順序を説明します。
+This page explains the role and execution order of the setup scripts under `scripts/`.
 
-## 実行順序
+## Execution order
 
-スクリプトはファイル名の番号プリフィックスによってグループ化されます。
+Scripts are grouped by the numeric prefix in the file name.
 
-| グループ             | 実行方法 | 説明                              |
-| -------------------- | -------- | --------------------------------- |
-| `000-*`              | 逐次     | OS 固有の初期設定                 |
-| `001-*`              | 逐次     | Homebrew のインストール           |
-| `002-*`              | 逐次     | Brewfile パッケージのインストール |
-| `100-*`（Brew 依存） | 逐次     | Homebrew パッケージに依存する設定 |
-| `100-*`（その他）    | 並列     | 独立したツール設定                |
+| Group                    | Execution method | Description                                     |
+| ------------------------ | ---------------- | ----------------------------------------------- |
+| `000-*`                  | Sequential       | OS-specific initial setup                       |
+| `001-*`                  | Sequential       | Homebrew installation                           |
+| `002-*`                  | Sequential       | Brewfile package installation                   |
+| `100-*` (Brew-dependent) | Sequential       | Configuration that depends on Homebrew packages |
+| `100-*` (others)         | Parallel         | Independent tool configuration                  |
 
-## スクリプト詳細
+## Script details
 
 ### 000-codespace.sh
 
-Codespaces (Ubuntu) 固有の初期設定を行います。macOS では何もしません。
+Performs Codespaces (Ubuntu)-specific initial setup. Does nothing on macOS.
 
-- タイムゾーンを `Asia/Tokyo` に設定
-- デフォルトシェルを zsh に変更
-- `build-essential`, `git` をインストール
+- Set the time zone to `Asia/Tokyo`
+- Change the default shell to zsh
+- Install `build-essential` and `git`
 
 ### 001-homebrew.sh
 
-Homebrew が未インストールの場合にインストールします。
+Installs Homebrew if it is not already installed.
 
 - macOS: `/opt/homebrew/bin/brew`
 - Linux: `/home/linuxbrew/.linuxbrew/bin/brew`
 
-インストール後に `gcc` をインストールし、全パッケージを `brew upgrade` でアップグレードします。
+After installation, it installs `gcc` and upgrades all packages with `brew upgrade`.
 
 ### 002-brewfile.sh
 
-`Brewfile` に定義されたパッケージを `brew bundle` でインストールします。
+Installs the packages defined in `Brewfile` with `brew bundle`.
 
 ### 100-gh-extensions.sh
 
-GitHub CLI の拡張機能をインストールし、関連ツールを追加します。
+Installs GitHub CLI extensions and adds related tools.
 
-- `gh-q`（HikaruEgashira/gh-q）拡張機能をインストール
-- `gh-infra`（babarot/gh-infra）拡張機能をインストール（`.github/settings.yml` による宣言的リポジトリ設定に使用。詳細は [gh-infra](./gh-infra.md) を参照）
-- `fd`（高速ファイル検索ツール）を Homebrew でインストール
+- Install the `gh-q` (`HikaruEgashira/gh-q`) extension
+- Install the `gh-infra` (`babarot/gh-infra`) extension (used for declarative repository settings with `.github/settings.yml`; see [gh-infra](./gh-infra.md) for details)
+- Install `fd` (a fast file search tool) with Homebrew
 
 ### 100-ghostty.sh
 
-Ghostty ターミナルエミュレータをインストールし、terminfo を設定します（未インストールの場合）。
+Installs the Ghostty terminal emulator and configures terminfo (if not already installed).
 
-- macOS: Homebrew cask からインストール
-- Linux: インストールスクリプトで導入
-- macOS では `/Applications/Ghostty.app` の terminfo を `~/.terminfo/` へコピー（`xterm-ghostty` 認識のため）
+- macOS: Install from Homebrew cask
+- Linux: Install with the installation script
+- On macOS, copy the terminfo from `/Applications/Ghostty.app` to `~/.terminfo/` (so `xterm-ghostty` is recognized)
 
 ### 100-lazyvim.sh
 
-LazyVim (Neovim 設定フレームワーク) の依存関係を設定します。
+Sets up dependencies for LazyVim (the Neovim configuration framework).
 
 ### 100-mise.sh
 
-mise で管理するツール群をインストールします（`mise install`）。
+Installs the tools managed by mise (`mise install`).
 
 ### 100-sheldon.sh
 
-sheldon と starship を Homebrew でインストールし、プラグインをロックファイルに従ってセットアップします。
+Installs sheldon and starship with Homebrew, then sets up plugins according to the lockfile.
 
-- `sheldon` と `starship` を Homebrew でインストール
-- `sheldon lock` でプラグインをインストール
+- Install `sheldon` and `starship` with Homebrew
+- Install plugins with `sheldon lock`
 
 ### 100-tmux.sh
 
-tmux Plugin Manager (tpm) をインストールし、プラグインと依存パッケージをセットアップします。
+Installs tmux Plugin Manager (tpm) and sets up plugins and dependency packages.
 
-- tpm を `~/.tmux/plugins/tpm/` にクローン（未インストールの場合）
-- tpm でプラグインをインストール
-- 共通パッケージを Homebrew でインストール: `bash`, `bc`, `coreutils`, `gawk`, `gh`, `git`, `jq`
-- macOS 追加: `glab`, `gsed`, `nowplaying-cli`, `font-noto-sans-symbols-2`
-- Linux 追加: `playerctl`
+- Clone tpm into `~/.tmux/plugins/tpm/` (if not already installed)
+- Install plugins with tpm
+- Install common packages with Homebrew: `bash`, `bc`, `coreutils`, `gawk`, `gh`, `git`, `jq`
+- Additional packages on macOS: `glab`, `gsed`, `nowplaying-cli`, `font-noto-sans-symbols-2`
+- Additional package on Linux: `playerctl`
 
-## Brew 依存スクリプト
+## Brew-dependent scripts
 
-以下のスクリプトは Homebrew パッケージに依存するため、並列実行されず逐次実行されます:
+The following scripts depend on Homebrew packages, so they are run sequentially instead of in parallel:
 
 - `100-ghostty.sh`
 - `100-lazyvim.sh`
 - `100-sheldon.sh`
 
-## スクリプトの追加
+## Adding scripts
 
-新しいスクリプトを追加する場合:
+When adding a new script:
 
-1. `scripts/` に `100-<name>.sh` を作成
-2. Homebrew に依存する場合は `install.sh` の `is_brew_dependent_100_script()` に追加
+1. Create `100-<name>.sh` in `scripts/`
+2. If it depends on Homebrew, add it to `is_brew_dependent_100_script()` in `install.sh`
 
 ```bash
 #!/bin/bash
 # scripts/100-new-tool.sh
 
-# ツールのセットアップ処理
+# Tool setup process
 ```

--- a/docs/reference/sheldon.md
+++ b/docs/reference/sheldon.md
@@ -1,52 +1,52 @@
 # Sheldon
 
-Zsh プラグインマネージャ（sheldon）の設定リファレンスです。
+This is the configuration reference for the Zsh plugin manager (sheldon).
 
-## ファイル
+## File
 
 `dotfiles/sheldon/plugins.toml` → `~/.config/sheldon/plugins.toml`
 
-## トップレベル設定
+## Top-level settings
 
 ```toml
 shell = "zsh"
 ```
 
-## テンプレート
+## Template
 
 ```toml
 [templates]
-fpath = "fpath=(\"{{ dir }}\" $fpath)"
+fpath = "fpath=("{{ dir }}" $fpath)"
 ```
 
-`apply = ["fpath"]` を指定したプラグインは source せず `fpath` に追加するのみ（補完定義の登録用）。
+Plugins that specify `apply = ["fpath"]` are not sourced and are only added to `fpath` (for registering completion definitions).
 
-## プラグイン一覧
+## Plugin list
 
-| プラグイン名                   | リポジトリ                                   | 説明                                             |
-| ------------------------------ | -------------------------------------------- | ------------------------------------------------ |
-| `fzf-tab`                      | `Aloxaf/fzf-tab`                             | zsh 標準補完を fzf に置き換え                    |
-| `ohmyzsh-lib-git`              | `ohmyzsh/ohmyzsh` (lib/git.zsh)              | git プラグインが依存するユーティリティ関数       |
-| `ohmyzsh-git`                  | `ohmyzsh/ohmyzsh` (plugins/git)              | Git エイリアス群（`gst`, `gco`, `gcm`, `gp` 等） |
-| `zsh-completions`              | `zsh-users/zsh-completions`                  | 追加の補完定義（fpath のみ）                     |
-| `zsh-autosuggestions`          | `zsh-users/zsh-autosuggestions`              | Fish 風の入力候補表示                            |
-| `zsh-autopair`                 | `hlissner/zsh-autopair`                      | 括弧・クォートの自動ペア                         |
-| `fast-syntax-highlighting`     | `zdharma-continuum/fast-syntax-highlighting` | コマンドのシンタックスハイライト                 |
-| `zsh-history-substring-search` | `zsh-users/zsh-history-substring-search`     | 入力中の文字列で履歴をサブストリング検索         |
+| Plugin name                    | Repository                                   | Description                                       |
+| ------------------------------ | -------------------------------------------- | ------------------------------------------------- |
+| `fzf-tab`                      | `Aloxaf/fzf-tab`                             | Replace standard zsh completion with fzf          |
+| `ohmyzsh-lib-git`              | `ohmyzsh/ohmyzsh` (lib/git.zsh)              | Utility functions required by the git plugin      |
+| `ohmyzsh-git`                  | `ohmyzsh/ohmyzsh` (plugins/git)              | Git alias set (`gst`, `gco`, `gcm`, `gp`, etc.)   |
+| `zsh-completions`              | `zsh-users/zsh-completions`                  | Additional completion definitions (`fpath` only)  |
+| `zsh-autosuggestions`          | `zsh-users/zsh-autosuggestions`              | Fish-style inline suggestions                     |
+| `zsh-autopair`                 | `hlissner/zsh-autopair`                      | Automatic pairing of brackets and quotes          |
+| `fast-syntax-highlighting`     | `zdharma-continuum/fast-syntax-highlighting` | Command syntax highlighting                       |
+| `zsh-history-substring-search` | `zsh-users/zsh-history-substring-search`     | Substring history search for the text being typed |
 
-## 読み込み順序の制約
+## Load-order constraints
 
-1. **compinit が先** — `.zshrc` で `compinit` を `sheldon source` より前に呼ぶ（`compdef` を使うプラグインが動作するため）
-2. **syntax highlighting の後に history-substring-search** — sheldon は TOML の定義順に source するため、`fast-syntax-highlighting` を先に書く
+1. **Run `compinit` first** — In `.zshrc`, call `compinit` before `sheldon source` so plugins that use `compdef` work correctly
+2. **Load `history-substring-search` after syntax highlighting** — sheldon sources plugins in TOML definition order, so write `fast-syntax-highlighting` first
 
-## プラグインの追加
+## Adding plugins
 
 ```toml
 [plugins.new-plugin]
 github = "author/new-plugin"
 ```
 
-追加後:
+After adding one:
 
 ```bash
 sheldon lock --update

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,19 +1,19 @@
 # Copilot Skills
 
-カスタムスキルの仕様リファレンスです。
+This is the specification reference for custom skills.
 
-## スキル一覧
+## Skill list
 
-| スキル      | 説明                                                                              |
-| ----------- | --------------------------------------------------------------------------------- |
-| `pr-create` | 対応する Task を確認し、変更内容を理解して適切なコミットメッセージと Description でドラフト PR を作成する |
-| `pr-fix`    | CI エラーの修正とレビューコメントへの対処を行い、PR をマージ可能な状態にする      |
+| Skill       | Description                                                                                                     |
+| ----------- | --------------------------------------------------------------------------------------------------------------- |
+| `pr-create` | Check the corresponding Task, understand the changes, and create a draft PR with an appropriate commit message and description |
+| `pr-fix`    | Fix CI errors and handle review comments to bring the PR into a mergeable state                                 |
 
-## インストール先
+## Installation destination
 
-`install.sh` 実行時に `dotfiles/skills/` → `~/.copilot/skills/` へシンボリックリンクされます。
+When `install.sh` runs, `dotfiles/skills/` is symlinked to `~/.copilot/skills/`.
 
-## ディレクトリ構成
+## Directory structure
 
 ```
 dotfiles/skills/
@@ -23,129 +23,129 @@ dotfiles/skills/
     └── SKILL.md
 ```
 
-## SKILL.md フォーマット仕様
+## `SKILL.md` format specification
 
-### 構造
+### Structure
 
-フロントマターは必須。本文のセクション構成はスキルの性質に応じて自由に定義する。
+Frontmatter is required. The section structure of the body can be freely defined according to the nature of the skill.
 
-**シンプルなスキルの例（`pr-create` 形式）:**
+**Example of a simple skill (`pr-create` style):**
 
 ```markdown
 ---
-description: スキルの説明（1行、日本語）
-name: スキル名
+description: Skill description (1 line, in Japanese)
+name: Skill name
 ---
 
-# スキル名
+# Skill name
 
-## 概要
+## Overview
 
-（スキルが何をするか）
+(What the skill does)
 
-## 使用タイミング
+## When to use
 
-（どのような状況で使うか）
+(What kind of situations it is used in)
 
-## 手順
+## Procedure
 
-### ステップ 1: ...
+### Step 1: ...
 
-### ステップ 2: ...
+### Step 2: ...
 
-## 出力
+## Output
 
-（スキルの出力内容）
+(What the skill outputs)
 ```
 
-**モード分岐があるスキルの例（`pr-fix` 形式）:**
+**Example of a skill with mode branching (`pr-fix` style):**
 
 ```markdown
 ---
-description: スキルの説明（1行、日本語）
-name: スキル名
+description: Skill description (1 line, in Japanese)
+name: Skill name
 ---
 
-# スキル名
+# Skill name
 
-## 使い方
+## Usage
 
-（呼び出し方と各モードの説明）
+(How to invoke it and an explanation of each mode)
 
-## モード
+## Modes
 
 ### mode-a — ...
 
 ### mode-b — ...
 
-## 共通ステップ
+## Common steps
 
-（全モードで行う処理）
+(Processing performed in all modes)
 
-## 制約事項
+## Constraints
 
-（制約条件）
+(Constraints)
 ```
 
-### フロントマター（必須）
+### Frontmatter (required)
 
-| フィールド    | 型     | 説明                                       |
-| ------------- | ------ | ------------------------------------------ |
-| `name`        | string | スキルの識別名。ディレクトリ名と一致させる |
-| `description` | string | スキルの概要。CLI のスキル一覧に表示される |
+| Field         | Type   | Description                                     |
+| ------------- | ------ | ----------------------------------------------- |
+| `name`        | string | Skill identifier. Must match the directory name |
+| `description` | string | Skill summary. Displayed in the CLI skill list  |
 
-### 本文の記述言語
+### Language used in the body
 
-- フロントマターの `description` は**日本語**で記述する（CLI のスキル一覧表示に使用される）
-- 本文は**日本語**で記述する
+- Write the frontmatter `description` in **Japanese** (used in the CLI skill list display)
+- Write the body in **Japanese**
 
-### セクションガイドライン
+### Section guidelines
 
-| セクション       | 必須 | 説明                                 |
-| ---------------- | ---- | ------------------------------------ |
-| 概要 or 使い方   | ✅   | スキルの目的や呼び出し方を説明       |
-| 手順 or モード   | ✅   | ステップまたはモード別の操作手順     |
-| 制約事項         | 推奨 | 制約事項・失敗時の振る舞い           |
-| 出力             | 推奨 | スキル完了時にユーザーに表示する内容 |
-| 開発者向けヒント | 任意 | エイリアス設定例など                 |
+| Section              | Required    | Description                                           |
+| -------------------- | ----------- | ----------------------------------------------------- |
+| Overview or Usage    | ✅          | Explain the purpose of the skill or how to invoke it  |
+| Procedure or Modes   | ✅          | Step-by-step or mode-specific operating procedure     |
+| Constraints          | Recommended | Constraints and behavior on failure                   |
+| Output               | Recommended | What is shown to the user when the skill finishes     |
+| Hints for developers | Optional    | Example alias configuration, etc.                     |
 
-## pr-create の詳細仕様
+## Detailed specification for `pr-create`
 
-### 動作フロー
+### Workflow
 
-1. 対応する Task (Issue) を確認（推測できない場合はユーザーに確認し、なければ作成を促す）
-2. `git diff` で変更内容を理解（Issue の Description・コメントも参照）
-3. Conventional Commits 形式でコミット
-4. feature ブランチにプッシュ
-5. PR Description を作成し（本文は日本語で記述）、ドラフト PR を `gh pr create --draft` で作成
-6. 呼び出したユーザーを Assignee に設定
-7. 対応する Task の Description を最終的な変更内容に合わせて更新（当初計画はコメントに退避）
+1. Check the corresponding Task (Issue) (if it cannot be inferred, ask the user to confirm; if there is none, encourage them to create one)
+2. Understand the changes with `git diff` (also refer to the Issue description and comments)
+3. Commit using the Conventional Commits format
+4. Push to the feature branch
+5. Create the PR description (write the body in Japanese), then create a draft PR with `gh pr create --draft`
+6. Set the invoking user as the Assignee
+7. Finally, update the corresponding Task description to match the final changes (move the original plan to a comment)
 
-### 入力
+### Input
 
-- ステージされたファイル、またはコミット済みの差分
-- オプション: 変更理由、関連 Issue 番号
+- Staged files, or already committed diffs
+- Optional: reason for the change, related Issue number
 
-### 出力
+### Output
 
-- 作成されたドラフト PR の URL
+- URL of the created draft PR
 
-## pr-fix の詳細仕様
+## Detailed specification for `pr-fix`
 
-### 動作フロー
+### Workflow
 
-1. 指定された PR の CI ステータスを確認
-2. CI 失敗がある場合、ログを分析し修正を繰り返す（最大 3 回）
-3. レビューコメントを全件取得し、各コメントの妥当性を判断
-4. 妥当なコメントは修正、不当なコメントはスキップ
-5. コミット・プッシュ前に `code-review` サブエージェントでローカルレビュー実施
-6. プッシュ後、各レビューコメントに対応内容をリプライ
+1. Check the CI status of the specified PR
+2. If there are CI failures, analyze the logs and repeat fixes (up to 3 times)
+3. Retrieve all review comments and judge the validity of each one
+4. Fix valid comments and skip invalid ones
+5. Before committing and pushing, run a local review with the `code-review` sub-agent
+6. After pushing, reply to each review comment with how it was addressed
 
-### 入力
+### Input
 
-- PR 番号（必須）
+- PR number (required)
 
-### 出力
+### Output
 
-- 各レビューコメントへのリプライ
-- CI が通らない場合はエラーレポート
+- Replies to each review comment
+- Error report if CI still does not pass

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -4,10 +4,10 @@ This is the specification reference for custom skills.
 
 ## Skill list
 
-| Skill       | Description                                                                                                     |
-| ----------- | --------------------------------------------------------------------------------------------------------------- |
+| Skill       | Description                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `pr-create` | Check the corresponding Task, understand the changes, and create a draft PR with an appropriate commit message and description |
-| `pr-fix`    | Fix CI errors and handle review comments to bring the PR into a mergeable state                                 |
+| `pr-fix`    | Fix CI errors and handle review comments to bring the PR into a mergeable state                                                |
 
 ## Installation destination
 
@@ -101,13 +101,13 @@ name: Skill name
 
 ### Section guidelines
 
-| Section              | Required    | Description                                           |
-| -------------------- | ----------- | ----------------------------------------------------- |
-| Overview or Usage    | ✅          | Explain the purpose of the skill or how to invoke it  |
-| Procedure or Modes   | ✅          | Step-by-step or mode-specific operating procedure     |
-| Constraints          | Recommended | Constraints and behavior on failure                   |
-| Output               | Recommended | What is shown to the user when the skill finishes     |
-| Hints for developers | Optional    | Example alias configuration, etc.                     |
+| Section              | Required    | Description                                          |
+| -------------------- | ----------- | ---------------------------------------------------- |
+| Overview or Usage    | ✅          | Explain the purpose of the skill or how to invoke it |
+| Procedure or Modes   | ✅          | Step-by-step or mode-specific operating procedure    |
+| Constraints          | Recommended | Constraints and behavior on failure                  |
+| Output               | Recommended | What is shown to the user when the skill finishes    |
+| Hints for developers | Optional    | Example alias configuration, etc.                    |
 
 ## Detailed specification for `pr-create`
 

--- a/docs/reference/starship.md
+++ b/docs/reference/starship.md
@@ -1,67 +1,67 @@
 # Starship
 
-クロスシェルプロンプト（Starship）の設定リファレンスです。
+This is the configuration reference for the cross-shell prompt (Starship).
 
-## ファイル
+## File
 
 `dotfiles/starship.toml` → `~/.config/starship.toml`
 
-## プロンプト構成
+## Prompt structure
 
-Powerline 風のグラデーションセグメントで構成される 2 行プロンプト:
+A two-line prompt composed of Powerline-style gradient segments:
 
 ```
 [░▒▓ ][directory][git_branch + git_status][languages][time]
 [character]
 ```
 
-### セグメントと配色
+### Segments and colors
 
-| セグメント              | 背景色    | 前景色    | 内容                                       |
-| ----------------------- | --------- | --------- | ------------------------------------------ |
-| アイコン                | `#a3aed2` | `#090c0c` | 固定アイコン ` `                           |
-| directory               | `#769ff0` | `#e3e5e5` | カレントディレクトリ（3 階層まで）         |
-| git_branch / git_status | `#394260` | `#769ff0` | ブランチ名 + ステータス                    |
-| languages               | `#212736` | `#769ff0` | Node.js / Bun / Rust / Go / PHP バージョン |
-| time                    | `#1d2230` | `#a0a9cb` | 現在時刻（`HH:MM`）                        |
+| Segment                 | Background | Foreground | Contents                                 |
+| ----------------------- | ---------- | ---------- | ---------------------------------------- |
+| Icon                    | `#a3aed2`  | `#090c0c`  | Fixed icon ` `                           |
+| directory               | `#769ff0`  | `#e3e5e5`  | Current directory (up to 3 levels)       |
+| git_branch / git_status | `#394260`  | `#769ff0`  | Branch name + status                     |
+| languages               | `#212736`  | `#769ff0`  | Node.js / Bun / Rust / Go / PHP versions |
+| time                    | `#1d2230`  | `#a0a9cb`  | Current time (`HH:MM`)                   |
 
-## モジュール設定
+## Module settings
 
 ### directory
 
-| キー                | 値   | 説明                           |
-| ------------------- | ---- | ------------------------------ |
-| `truncation_length` | `3`  | 表示する最大ディレクトリ階層数 |
-| `truncation_symbol` | `…/` | 省略時の記号                   |
+| Key                 | Value | Description                                   |
+| ------------------- | ----- | --------------------------------------------- |
+| `truncation_length` | `3`   | Maximum number of directory levels to display |
+| `truncation_symbol` | `…/`  | Symbol used when truncated                    |
 
-特殊ディレクトリの置換:
+Special directory replacements:
 
-| ディレクトリ | 表示 |
-| ------------ | ---- |
-| Documents    | `󰈙 ` |
-| Downloads    | ` `  |
-| Music        | ` `  |
-| Pictures     | ` `  |
+| Directory | Display |
+| --------- | ------- |
+| Documents | `󰈙 `    |
+| Downloads | ` `     |
+| Music     | ` `     |
+| Pictures  | ` `     |
 
 ### git_branch
 
-ブランチシンボル: `` （Nerd Font）
+Branch symbol: `` (Nerd Font)
 
-### 言語モジュール
+### Language modules
 
-検出された言語のバージョンを表示。すべて同じスタイルで統一:
+Displays the version of detected languages. All use the same unified style:
 
-| モジュール | シンボル |
-| ---------- | -------- |
-| `nodejs`   | ``       |
-| `bun`      | ``       |
-| `rust`     | ``       |
-| `golang`   | ``       |
-| `php`      | ``       |
+| Module   | Symbol |
+| -------- | ------ |
+| `nodejs` | ``     |
+| `bun`    | ``     |
+| `rust`   | ``     |
+| `golang` | ``     |
+| `php`    | ``     |
 
 ### time
 
-| キー          | 値      | 説明         |
-| ------------- | ------- | ------------ |
-| `disabled`    | `false` | 有効         |
-| `time_format` | `%R`    | `HH:MM` 形式 |
+| Key           | Value   | Description    |
+| ------------- | ------- | -------------- |
+| `disabled`    | `false` | Enabled        |
+| `time_format` | `%R`    | `HH:MM` format |

--- a/docs/reference/tmux.md
+++ b/docs/reference/tmux.md
@@ -1,63 +1,63 @@
 # tmux
 
-ターミナルマルチプレクサ（tmux）の設定リファレンスです。
+This is the configuration reference for the terminal multiplexer (tmux).
 
-## ファイル
+## File
 
 `dotfiles/tmux.conf` → `~/.tmux.conf`
 
-## 基本設定
+## Basic settings
 
-| 設定               | 値              | 説明                                              |
-| ------------------ | --------------- | ------------------------------------------------- |
-| prefix             | `C-t`           | プレフィックスキー（デフォルトの `C-b` を無効化） |
-| `default-terminal` | `xterm-ghostty` | Ghostty の機能を tmux 内でも維持                  |
-| `mode-keys`        | `vi`            | コピーモードで vi キーバインド                    |
+| Setting            | Value           | Description                                 |
+| ------------------ | --------------- | ------------------------------------------- |
+| prefix             | `C-t`           | Prefix key (disables the default `C-b`)     |
+| `default-terminal` | `xterm-ghostty` | Preserve Ghostty features even inside tmux  |
+| `mode-keys`        | `vi`            | vi keybindings in copy mode                 |
 
-## キーバインド
+## Keybindings
 
-### ウィンドウ・ペイン操作
+### Window and pane operations
 
-| キー             | 動作                                     |
-| ---------------- | ---------------------------------------- |
-| `prefix c`       | 新規ウィンドウ（カレントパスを引き継ぐ） |
-| `prefix \`       | 水平分割（カレントパスを引き継ぐ）       |
-| `prefix -`       | 垂直分割（カレントパスを引き継ぐ）       |
-| `prefix h/j/k/l` | ペイン移動（vim 風）                     |
-| `prefix r`       | 設定リロード                             |
+| Key              | Action                                       |
+| ---------------- | -------------------------------------------- |
+| `prefix c`       | New window (inherits the current path)       |
+| `prefix \`      | Horizontal split (inherits the current path) |
+| `prefix -`       | Vertical split (inherits the current path)   |
+| `prefix h/j/k/l` | Move between panes (vim-style)               |
+| `prefix r`       | Reload configuration                         |
 
-### コピーモード
+### Copy mode
 
-| キー | 動作                     |
-| ---- | ------------------------ |
-| `v`  | 選択開始                 |
-| `y`  | コピー＆コピーモード終了 |
+| Key | Action                  |
+| --- | ----------------------- |
+| `v` | Start selection         |
+| `y` | Copy and exit copy mode |
 
-### 特殊キー
+### Special keys
 
-| キー          | 動作                                         |
-| ------------- | -------------------------------------------- |
-| `Shift+Enter` | `\e[13;2u` を送信（kitty keyboard protocol） |
+| Key           | Action                                     |
+| ------------- | ------------------------------------------ |
+| `Shift+Enter` | Send `\e[13;2u` (kitty keyboard protocol) |
 
-## プラグイン
+## Plugins
 
-TPM (Tmux Plugin Manager) で管理。プラグインディレクトリ: `~/.tmux/plugins/`
+Managed by TPM (Tmux Plugin Manager). Plugin directory: `~/.tmux/plugins/`
 
-| プラグイン                    | 説明                           |
-| ----------------------------- | ------------------------------ |
-| `tmux-plugins/tpm`            | プラグインマネージャ本体       |
-| `tmux-plugins/tmux-sensible`  | 基本的なベストプラクティス設定 |
-| `janoamaral/tokyo-night-tmux` | Tokyo Night テーマ             |
+| Plugin                        | Description                  |
+| ----------------------------- | ---------------------------- |
+| `tmux-plugins/tpm`            | Plugin manager itself        |
+| `tmux-plugins/tmux-sensible`  | Basic best-practice settings |
+| `janoamaral/tokyo-night-tmux` | Tokyo Night theme            |
 
-### Tokyo Night 設定
+### Tokyo Night settings
 
-| キー                      | 値      | 説明             |
-| ------------------------- | ------- | ---------------- |
-| `@tokyo-night-tmux_theme` | `storm` | Storm バリアント |
+| Key                       | Value   | Description   |
+| ------------------------- | ------- | ------------- |
+| `@tokyo-night-tmux_theme` | `storm` | Storm variant |
 
-## 自動起動
+## Auto-start
 
-`.zshrc` で tmux セッションに自動接続する:
+In `.zshrc`, automatically connect to a tmux session:
 
 ```zsh
 if [[ -z "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
@@ -65,15 +65,15 @@ if [[ -z "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
 fi
 ```
 
-- `new-session -A -s main` — `main` セッションが存在すれば attach、なければ作成
-- `exec` — シェルを tmux に置き換え（tmux 終了時にターミナルが閉じる）
+- `new-session -A -s main` — Attach if the `main` session exists; otherwise create it
+- `exec` — Replace the shell with tmux (the terminal closes when tmux exits)
 
-## TPM の初期化
+## Initializing TPM
 
-Homebrew のパスをプリペンドして TPM を起動:
+Start TPM after prepending the Homebrew path:
 
 ```
 run 'PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH" ~/.tmux/plugins/tpm/tpm'
 ```
 
-これにより TPM のプラグインスクリプトが Homebrew の bash 5+ を使用できる。
+This allows TPM's plugin scripts to use Homebrew's bash 5+.

--- a/docs/reference/tmux.md
+++ b/docs/reference/tmux.md
@@ -8,11 +8,11 @@ This is the configuration reference for the terminal multiplexer (tmux).
 
 ## Basic settings
 
-| Setting            | Value           | Description                                 |
-| ------------------ | --------------- | ------------------------------------------- |
-| prefix             | `C-t`           | Prefix key (disables the default `C-b`)     |
-| `default-terminal` | `xterm-ghostty` | Preserve Ghostty features even inside tmux  |
-| `mode-keys`        | `vi`            | vi keybindings in copy mode                 |
+| Setting            | Value           | Description                                |
+| ------------------ | --------------- | ------------------------------------------ |
+| prefix             | `C-t`           | Prefix key (disables the default `C-b`)    |
+| `default-terminal` | `xterm-ghostty` | Preserve Ghostty features even inside tmux |
+| `mode-keys`        | `vi`            | vi keybindings in copy mode                |
 
 ## Keybindings
 
@@ -21,7 +21,7 @@ This is the configuration reference for the terminal multiplexer (tmux).
 | Key              | Action                                       |
 | ---------------- | -------------------------------------------- |
 | `prefix c`       | New window (inherits the current path)       |
-| `prefix \`      | Horizontal split (inherits the current path) |
+| `prefix \`       | Horizontal split (inherits the current path) |
 | `prefix -`       | Vertical split (inherits the current path)   |
 | `prefix h/j/k/l` | Move between panes (vim-style)               |
 | `prefix r`       | Reload configuration                         |
@@ -35,8 +35,8 @@ This is the configuration reference for the terminal multiplexer (tmux).
 
 ### Special keys
 
-| Key           | Action                                     |
-| ------------- | ------------------------------------------ |
+| Key           | Action                                    |
+| ------------- | ----------------------------------------- |
 | `Shift+Enter` | Send `\e[13;2u` (kitty keyboard protocol) |
 
 ## Plugins

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,41 +1,41 @@
-# ツール一覧
+# Tool list
 
-Brewfile で管理しているツールの一覧と用途です。
+This is the list of tools managed in the Brewfile and their purposes.
 
-## CLI ツール
+## CLI tools
 
-| パッケージ | 用途                                           |
-| ---------- | ---------------------------------------------- |
-| `gcc`      | Homebrew ビルド依存                            |
-| `bun`      | JavaScript ランタイム / パッケージマネージャ   |
-| `fish`     | Fish shell（サブシェル用）                     |
-| `fzf`      | ファジーファインダー（ファイル選択、履歴検索） |
-| `gh`       | GitHub CLI                                     |
-| `git`      | バージョン管理                                 |
-| `jq`       | JSON プロセッサ                                |
-| `lazygit`  | Git の TUI クライアント                        |
-| `lua`      | Lua ランタイム（Neovim プラグイン用）          |
-| `luarocks` | Lua パッケージマネージャ                       |
-| `mise`     | 開発ツールバージョン管理                       |
-| `neovim`   | テキストエディタ                               |
-| `node`     | Node.js ランタイム                             |
-| `ripgrep`  | 高速テキスト検索                               |
-| `rtk`      | LLM トークン削減 CLI プロキシ                  |
-| `sheldon`  | Zsh プラグインマネージャ                       |
-| `starship` | クロスシェルプロンプト                         |
-| `tmux`     | ターミナルマルチプレクサ                       |
-| `wget`     | HTTP ダウンローダ                              |
+| Package    | Purpose                                       |
+| ---------- | --------------------------------------------- |
+| `gcc`      | Homebrew build dependency                     |
+| `bun`      | JavaScript runtime / package manager          |
+| `fish`     | Fish shell (for subshell use)                 |
+| `fzf`      | Fuzzy finder (file selection, history search) |
+| `gh`       | GitHub CLI                                    |
+| `git`      | Version control                               |
+| `jq`       | JSON processor                                |
+| `lazygit`  | TUI client for Git                            |
+| `lua`      | Lua runtime (for Neovim plugins)              |
+| `luarocks` | Lua package manager                           |
+| `mise`     | Development tool version management           |
+| `neovim`   | Text editor                                   |
+| `node`     | Node.js runtime                               |
+| `ripgrep`  | Fast text search                              |
+| `rtk`      | CLI proxy for reducing LLM token usage        |
+| `sheldon`  | Zsh plugin manager                            |
+| `starship` | Cross-shell prompt                            |
+| `tmux`     | Terminal multiplexer                          |
+| `wget`     | HTTP downloader                               |
 
-## GUI アプリケーション（cask）
+## GUI applications (cask)
 
-| パッケージ             | 用途                                   |
-| ---------------------- | -------------------------------------- |
-| `copilot-cli`          | GitHub Copilot CLI                     |
-| `font-moralerspace-hw` | プログラミング用フォント（macOS のみ） |
+| Package                | Purpose                       |
+| ---------------------- | ----------------------------- |
+| `copilot-cli`          | GitHub Copilot CLI            |
+| `font-moralerspace-hw` | Programming font (macOS only) |
 
-## ツールの追加
+## Adding tools
 
-`Brewfile` にエントリを追加し、`install.sh` を再実行するか `brew bundle` を直接実行します。
+Add an entry to `Brewfile`, then rerun `install.sh` or run `brew bundle` directly.
 
 ```bash
 echo 'brew "new-tool"' >> Brewfile

--- a/docs/reference/zsh/README.md
+++ b/docs/reference/zsh/README.md
@@ -28,22 +28,22 @@ This is the reference for Zsh shell configuration.
 
 ## History settings
 
-| Option                 | Description                                               |
-| ---------------------- | --------------------------------------------------------- |
-| `extended_history`     | Record timestamps and execution time                      |
-| `hist_ignore_all_dups` | Remove duplicates completely                              |
-| `hist_ignore_dups`     | Do not record the same command as the previous one        |
-| `hist_ignore_space`    | Do not record commands that start with a space            |
-| `hist_reduce_blanks`   | Remove extra spaces                                       |
-| `hist_verify`          | Show history expansion without executing it immediately   |
-| `share_history`        | Share history across sessions                             |
+| Option                 | Description                                             |
+| ---------------------- | ------------------------------------------------------- |
+| `extended_history`     | Record timestamps and execution time                    |
+| `hist_ignore_all_dups` | Remove duplicates completely                            |
+| `hist_ignore_dups`     | Do not record the same command as the previous one      |
+| `hist_ignore_space`    | Do not record commands that start with a space          |
+| `hist_reduce_blanks`   | Remove extra spaces                                     |
+| `hist_verify`          | Show history expansion without executing it immediately |
+| `share_history`        | Share history across sessions                           |
 
 ## Directory settings
 
-| Option              | Description                                   |
-| ------------------- | --------------------------------------------- |
-| `auto_cd`           | Run `cd` with only a directory name           |
-| `auto_pushd`        | Automatically run `pushd` on `cd`             |
+| Option              | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `auto_cd`           | Run `cd` with only a directory name               |
+| `auto_pushd`        | Automatically run `pushd` on `cd`                 |
 | `pushd_ignore_dups` | Remove duplicate entries from the directory stack |
 
 ## Completion style

--- a/docs/reference/zsh/README.md
+++ b/docs/reference/zsh/README.md
@@ -1,55 +1,55 @@
 # Zsh
 
-Zsh シェル設定のリファレンスです。
+This is the reference for Zsh shell configuration.
 
-## ファイル
+## Files
 
-| ソース           | リンク先   | 内容                           |
-| ---------------- | ---------- | ------------------------------ |
-| `dotfiles/zshrc` | `~/.zshrc` | メイン設定ファイル             |
-| `dotfiles/zsh/`  | `~/.zsh/`  | カスタムプラグインディレクトリ |
+| Source           | Link destination | Contents                |
+| ---------------- | ---------------- | ----------------------- |
+| `dotfiles/zshrc` | `~/.zshrc`       | Main configuration file |
+| `dotfiles/zsh/`  | `~/.zsh/`        | Custom plugin directory |
 
-## .zshrc の構成
+## `.zshrc` structure
 
-`.zshrc` は以下の順序で処理される:
+`.zshrc` is processed in the following order:
 
-1. **tmux 自動起動** — tmux セッションに接続/作成
-2. **Homebrew** — シェル環境変数を設定
-3. **compinit** — 補完システムを初期化（sheldon より先に必要）
-4. **Emacs キーバインド** — `bindkey -e`
-5. **Sheldon** — プラグインを読み込み
-6. **History 設定** — 履歴のオプション
-7. **Directory 設定** — `auto_cd`, `auto_pushd`
-8. **補完スタイル** — 大小文字・ハイフン非区別
+1. **Auto-start tmux** — Connect to or create a tmux session
+2. **Homebrew** — Set shell environment variables
+3. **compinit** — Initialize the completion system (must come before sheldon)
+4. **Emacs keybindings** — `bindkey -e`
+5. **Sheldon** — Load plugins
+6. **History settings** — History options
+7. **Directory settings** — `auto_cd`, `auto_pushd`
+8. **Completion style** — Case-insensitive and hyphen-insensitive matching
 9. **EDITOR** — `nvim`
-10. **Starship** — プロンプトを初期化
-11. **mise** — ランタイムバージョン管理を有効化
-12. **カスタム関数** — `~/.zsh/*.zsh` をすべて source
+10. **Starship** — Initialize the prompt
+11. **mise** — Enable runtime version management
+12. **Custom functions** — Source all `~/.zsh/*.zsh`
 
-## History 設定
+## History settings
 
-| オプション             | 説明                                 |
-| ---------------------- | ------------------------------------ |
-| `extended_history`     | タイムスタンプと実行時間を記録       |
-| `hist_ignore_all_dups` | 重複を完全に除去                     |
-| `hist_ignore_dups`     | 直前と同じコマンドを記録しない       |
-| `hist_ignore_space`    | スペース始まりのコマンドを記録しない |
-| `hist_reduce_blanks`   | 余分な空白を除去                     |
-| `hist_verify`          | 履歴展開をすぐ実行せず表示           |
-| `share_history`        | セッション間で履歴を共有             |
+| Option                 | Description                                               |
+| ---------------------- | --------------------------------------------------------- |
+| `extended_history`     | Record timestamps and execution time                      |
+| `hist_ignore_all_dups` | Remove duplicates completely                              |
+| `hist_ignore_dups`     | Do not record the same command as the previous one        |
+| `hist_ignore_space`    | Do not record commands that start with a space            |
+| `hist_reduce_blanks`   | Remove extra spaces                                       |
+| `hist_verify`          | Show history expansion without executing it immediately   |
+| `share_history`        | Share history across sessions                             |
 
-## Directory 設定
+## Directory settings
 
-| オプション          | 説明                             |
-| ------------------- | -------------------------------- |
-| `auto_cd`           | ディレクトリ名だけで `cd`        |
-| `auto_pushd`        | `cd` 時に自動で `pushd`          |
-| `pushd_ignore_dups` | ディレクトリスタックの重複を除去 |
+| Option              | Description                                   |
+| ------------------- | --------------------------------------------- |
+| `auto_cd`           | Run `cd` with only a directory name           |
+| `auto_pushd`        | Automatically run `pushd` on `cd`             |
+| `pushd_ignore_dups` | Remove duplicate entries from the directory stack |
 
-## 補完スタイル
+## Completion style
 
 ```zsh
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z-_}={A-Za-z_-}'
 ```
 
-大文字小文字とハイフン/アンダースコアを区別せずに補完する。
+Complete without distinguishing uppercase/lowercase and hyphen/underscore.

--- a/docs/reference/zsh/plugins.md
+++ b/docs/reference/zsh/plugins.md
@@ -36,13 +36,13 @@ Runs automatically on every `cd` via the `chpwd` hook:
 
 ### Functions provided
 
-| Function                    | Description                                                 |
-| --------------------------- | ----------------------------------------------------------- |
-| `is_github_origin_repo`     | Determine whether `origin` is `github.com`                 |
-| `resolve_gh_identity`       | Get login name, name, and email from `gh api`              |
-| `sync_signing_key_from_gh`  | Set the SSH signing key and `allowed_signers`              |
+| Function                    | Description                                                  |
+| --------------------------- | ------------------------------------------------------------ |
+| `is_github_origin_repo`     | Determine whether `origin` is `github.com`                   |
+| `resolve_gh_identity`       | Get login name, name, and email from `gh api`                |
+| `sync_signing_key_from_gh`  | Set the SSH signing key and `allowed_signers`                |
 | `sync_git_identity_from_gh` | Sync `user.name`, `user.email`, and the signing key together |
-| `set_gh_config_dir`         | Set `GH_CONFIG_DIR` and call identity sync                 |
+| `set_gh_config_dir`         | Set `GH_CONFIG_DIR` and call identity sync                   |
 
 For details, see [Automatic Git identity switching](../../guides/04-git-identity.md).
 

--- a/docs/reference/zsh/plugins.md
+++ b/docs/reference/zsh/plugins.md
@@ -1,68 +1,68 @@
-# Zsh カスタムプラグイン
+# Zsh Custom Plugins
 
-`dotfiles/zsh/` に配置されたカスタムプラグインの詳細リファレンスです。
+This is the detailed reference for the custom plugins placed in `dotfiles/zsh/`.
 
-## 一覧
+## List
 
-| ファイル                          | エイリアス | キーバインド | 説明                                  |
-| --------------------------------- | ---------- | ------------ | ------------------------------------- |
-| `gh-config-dir.zsh`               | —          | —            | Git identity + GH_CONFIG_DIR 自動設定 |
-| `go-to-ghq-repository.zsh`        | `ggr`      | `C-]`        | リポジトリ選択して `cd`               |
-| `edit-ghq-repository.zsh`         | `egr`      | —            | リポジトリ選択して nvim で開く        |
-| `edit-selected-file.zsh`          | `esf`      | —            | ファイル選択して nvim で開く          |
-| `fzf-select-history.zsh`          | —          | `C-r`        | fzf で履歴検索                        |
-| `browse-github-notifications.zsh` | `bgn`      | —            | GitHub 通知を閲覧                     |
-| `open-lazygit.zsh`                | `olg`      | —            | lazygit を起動                        |
-| `run-selected-command.zsh`        | —          | —            | コマンド実行ユーティリティ            |
-| `history-substring-search.zsh`    | —          | `↑` / `↓`    | サブストリング履歴検索                |
-| `zshaddhistory.zsh`               | —          | —            | 失敗コマンドを履歴から除外            |
+| File                              | Alias | Keybinding | Description                                              |
+| --------------------------------- | ----- | ---------- | -------------------------------------------------------- |
+| `gh-config-dir.zsh`               | —     | —          | Automatically configure Git identity and `GH_CONFIG_DIR` |
+| `go-to-ghq-repository.zsh`        | `ggr` | `C-]`      | Select a repository and `cd` into it                     |
+| `edit-ghq-repository.zsh`         | `egr` | —          | Select a repository and open it in `nvim`                |
+| `edit-selected-file.zsh`          | `esf` | —          | Select a file and open it in `nvim`                      |
+| `fzf-select-history.zsh`          | —     | `C-r`      | Search history with fzf                                  |
+| `browse-github-notifications.zsh` | `bgn` | —          | Browse GitHub notifications                              |
+| `open-lazygit.zsh`                | `olg` | —          | Launch lazygit                                           |
+| `run-selected-command.zsh`        | —     | —          | Command execution utility                                |
+| `history-substring-search.zsh`    | —     | `↑` / `↓`  | Substring history search                                 |
+| `zshaddhistory.zsh`               | —     | —          | Exclude failed commands from history                     |
 
 ---
 
 ## gh-config-dir.zsh
 
-リポジトリごとに GitHub アカウント情報と SSH 署名鍵を自動設定する最重要プラグイン。
+The most important plugin, which automatically configures GitHub account information and the SSH signing key for each repository.
 
-### 動作
+### Behavior
 
-`chpwd` フックで `cd` のたびに自動実行:
+Runs automatically on every `cd` via the `chpwd` hook:
 
-1. Git リポジトリ内であることを確認
-2. `.git/gh/` を作成し `GH_CONFIG_DIR` に設定（`gh` の認証を分離）
-3. GitHub origin の場合のみ、以下の identity 同期を実行:
-   - ローカルに `user.name` / `user.email` が未設定なら `gh api` で取得して設定
-   - `~/.ssh/<login>.pub` を `user.signingkey` に設定
-   - `~/.ssh/allowed_signers` を更新
+1. Check whether the current directory is inside a Git repository
+2. Create `.git/gh/` and set it in `GH_CONFIG_DIR` (isolates `gh` authentication)
+3. Only for GitHub origins, perform the following identity sync:
+   - If local `user.name` / `user.email` are not set, fetch them with `gh api` and set them
+   - Set `~/.ssh/<login>.pub` as `user.signingkey`
+   - Update `~/.ssh/allowed_signers`
 
-### 提供する関数
+### Functions provided
 
-| 関数                        | 説明                                                |
-| --------------------------- | --------------------------------------------------- |
-| `is_github_origin_repo`     | origin が github.com か判定                         |
-| `resolve_gh_identity`       | `gh api` からログイン名・名前・メールを取得         |
-| `sync_signing_key_from_gh`  | SSH 署名鍵と allowed_signers を設定                 |
-| `sync_git_identity_from_gh` | user.name / user.email / signing key をまとめて同期 |
-| `set_gh_config_dir`         | GH_CONFIG_DIR を設定し identity 同期を呼び出す      |
+| Function                    | Description                                                 |
+| --------------------------- | ----------------------------------------------------------- |
+| `is_github_origin_repo`     | Determine whether `origin` is `github.com`                 |
+| `resolve_gh_identity`       | Get login name, name, and email from `gh api`              |
+| `sync_signing_key_from_gh`  | Set the SSH signing key and `allowed_signers`              |
+| `sync_git_identity_from_gh` | Sync `user.name`, `user.email`, and the signing key together |
+| `set_gh_config_dir`         | Set `GH_CONFIG_DIR` and call identity sync                 |
 
-詳細は [Git ID の自動切り替え](../../guides/04-git-identity.md) を参照。
+For details, see [Automatic Git identity switching](../../guides/04-git-identity.md).
 
 ---
 
 ## go-to-ghq-repository.zsh
 
-`gh q list` でリポジトリ一覧を取得し、fzf で選択して `cd` する。
+Get a repository list with `gh q list`, select one with fzf, and `cd` into it.
 
-### 動作
+### Behavior
 
-1. `gh q list` でローカルリポジトリのパス一覧を取得
-2. `github.com` プレフィックスを除去して表示
-3. fzf で選択されたパスに `cd`
+1. Get a list of local repository paths with `gh q list`
+2. Display them after removing the `github.com` prefix
+3. `cd` into the path selected with fzf
 
-### キーバインド
+### Keybinding
 
-- `C-]` — ZLE ウィジェットとして呼び出し
+- `C-]` — Invoke as a ZLE widget
 
-### エイリアス
+### Alias
 
 - `ggr`
 
@@ -70,13 +70,13 @@
 
 ## edit-ghq-repository.zsh
 
-`gh q nvim` でリポジトリを選択して Neovim で開く。
+Select a repository with `gh q nvim` and open it in Neovim.
 
-### 動作
+### Behavior
 
-`run-selected-command` を経由して `gh q nvim` を実行する。
+Runs `gh q nvim` via `run-selected-command`.
 
-### エイリアス
+### Alias
 
 - `egr`
 
@@ -84,14 +84,14 @@
 
 ## edit-selected-file.zsh
 
-fzf でファイルを選択して Neovim で開く。
+Select a file with fzf and open it in Neovim.
 
-### 動作
+### Behavior
 
-1. `fzf` でファイルを選択（リスト元は `$FZF_DEFAULT_COMMAND` または fzf のデフォルト）
-2. `run-selected-command` を経由して `nvim <file>` を実行
+1. Select a file with `fzf` (the source list comes from `$FZF_DEFAULT_COMMAND` or fzf's default)
+2. Run `nvim <file>` via `run-selected-command`
 
-### エイリアス
+### Alias
 
 - `esf`
 
@@ -99,35 +99,35 @@ fzf でファイルを選択して Neovim で開く。
 
 ## fzf-select-history.zsh
 
-fzf を使ったインタラクティブ履歴検索。
+Interactive history search using fzf.
 
-### 動作
+### Behavior
 
-1. `history -n -r 1` で全履歴を新しい順に取得
-2. 現在のコマンドライン（`$LBUFFER`）をクエリとして fzf に渡す
-3. 選択された履歴をコマンドラインにセット
+1. Get the full history in newest-first order with `history -n -r 1`
+2. Pass the current command line (`$LBUFFER`) to fzf as the query
+3. Set the selected history entry onto the command line
 
-### キーバインド
+### Keybinding
 
-- `C-r` — ZLE ウィジェットとして呼び出し
+- `C-r` — Invoke as a ZLE widget
 
 ---
 
 ## browse-github-notifications.zsh
 
-未読の GitHub 通知（Issue / PR）を一覧表示し、選択して詳細を開く。
+List unread GitHub notifications (Issues / PRs), then select one and open its details.
 
-### 動作
+### Behavior
 
-1. `gh api notifications` で未読通知を取得（全ページ）
-2. Issue / PR のみをフィルタしてテーブル表示（リポジトリ#番号 / タイトル / 理由）
-3. fzf で選択し、`gh pr view` または `gh issue view` を実行
+1. Get unread notifications with `gh api notifications` (all pages)
+2. Filter only Issues / PRs and display them as a table (`repository#number / title / reason`)
+3. Select one with fzf, then run `gh pr view` or `gh issue view`
 
-### 依存
+### Dependencies
 
 `gh`, `jq`, `fzf`, `column`
 
-### エイリアス
+### Alias
 
 - `bgn`
 
@@ -135,14 +135,14 @@ fzf を使ったインタラクティブ履歴検索。
 
 ## open-lazygit.zsh
 
-lazygit を起動し、終了時にカレントディレクトリを lazygit 内で移動した先に同期する。
+Launch lazygit and, on exit, synchronize the current directory with the location moved to inside lazygit.
 
-### 動作
+### Behavior
 
-1. `LAZYGIT_NEW_DIR_FILE` を設定して lazygit を起動
-2. lazygit 終了後、ファイルに書かれたディレクトリに `cd`
+1. Set `LAZYGIT_NEW_DIR_FILE` and launch lazygit
+2. After lazygit exits, `cd` into the directory written to the file
 
-### エイリアス
+### Alias
 
 - `olg`
 
@@ -150,14 +150,14 @@ lazygit を起動し、終了時にカレントディレクトリを lazygit 内
 
 ## run-selected-command.zsh
 
-他のプラグインから呼ばれるユーティリティ関数。
+A utility function called by other plugins.
 
-### 動作
+### Behavior
 
-- ZLE コンテキスト（`$WIDGET` が設定されている）: コマンドをバッファにセットして `accept-line`
-- 通常コンテキスト: 履歴に追加してから直接実行
+- ZLE context (`$WIDGET` is set): Put the command in the buffer and call `accept-line`
+- Normal context: Add it to history, then execute it directly
 
-### インターフェース
+### Interface
 
 ```zsh
 run-selected-command "command_line_string" cmd arg1 arg2 ...
@@ -167,21 +167,21 @@ run-selected-command "command_line_string" cmd arg1 arg2 ...
 
 ## history-substring-search.zsh
 
-`zsh-history-substring-search` プラグインのキーバインド設定。
+Keybinding settings for the `zsh-history-substring-search` plugin.
 
-### キーバインド
+### Keybindings
 
-| キー         | 動作                             |
-| ------------ | -------------------------------- |
-| `↑` (`^[[A`) | 入力中の文字列で上方向に履歴検索 |
-| `↓` (`^[[B`) | 入力中の文字列で下方向に履歴検索 |
+| Key          | Action                                                     |
+| ------------ | ---------------------------------------------------------- |
+| `↑` (`^[[A`) | Search backward through history using the text being typed |
+| `↓` (`^[[B`) | Search forward through history using the text being typed  |
 
 ---
 
 ## zshaddhistory.zsh
 
-直前のコマンドが失敗（終了コード ≠ 0）した場合に履歴への記録をスキップする。
+Skip recording a command in history if the immediately previous command failed (exit code ≠ 0).
 
-### 動作
+### Behavior
 
-`zshaddhistory` フック関数を定義し、`$?` が 0 でなければ `false` を返す（= 履歴に追加しない）。
+Define the `zshaddhistory` hook function and return `false` when `$?` is not 0 (= do not add to history).

--- a/dotfiles/copilot-instructions.md
+++ b/dotfiles/copilot-instructions.md
@@ -1,13 +1,13 @@
 # Copilot Personal Instructions
 
-## Pull Request 用スキル
+## Pull Request skills
 
-ユーザーが `/pr create` を実行するか、Pull Request の作成を依頼した場合は、必ず `pr-create` スキルを使う。
-ユーザーが `/pr fix` を実行するか、Pull Request を修正・改善・マージ可能な状態にするよう依頼した場合は、必ず `pr-fix` スキルを使う。
+If the user runs `/pr create` or asks to create a Pull Request, always use the `pr-create` skill.
+If the user runs `/pr fix` or asks to fix, improve, or make a Pull Request mergeable, always use the `pr-fix` skill.
 
-## Issue / Pull Request へのコメント
+## Comments on Issues / Pull Requests
 
-ユーザーの指示で Issue や Pull Request へコメントやリプライをする場合は、先頭に必ず `:robot:` を付ける。
+When posting a comment or reply on an Issue or Pull Request at the user's instruction, always prefix it with `:robot:`.
 
 <!-- rtk-instructions v2 -->
 # RTK — Token-Optimized CLI

--- a/dotfiles/copilot-instructions.md
+++ b/dotfiles/copilot-instructions.md
@@ -10,6 +10,7 @@ If the user runs `/pr fix` or asks to fix, improve, or make a Pull Request merge
 When posting a comment or reply on an Issue or Pull Request at the user's instruction, always prefix it with `:robot:`.
 
 <!-- rtk-instructions v2 -->
+
 # RTK — Token-Optimized CLI
 
 **rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
@@ -35,4 +36,5 @@ rtk gain --history    # Per-command savings history
 rtk discover          # Find missed rtk opportunities
 rtk proxy <cmd>       # Run raw (no filtering) but track usage
 ```
+
 <!-- /rtk-instructions -->

--- a/dotfiles/skills/pr-create/SKILL.md
+++ b/dotfiles/skills/pr-create/SKILL.md
@@ -65,7 +65,7 @@ It understands staged files and committed changes, then creates the PR with an a
 ### Step 5: Create the PR description and open a draft PR
 
 - If `.github/pull_request_template.md` exists, follow its structure
-- Write the PR body in Japanese
+- Write the PR body in English
 - Include the following in the description:
   - **Purpose:**
     - What this PR accomplishes, including not only **what** but also **why**

--- a/dotfiles/skills/pr-create/SKILL.md
+++ b/dotfiles/skills/pr-create/SKILL.md
@@ -1,99 +1,99 @@
 ---
 name: pr-create
-description: Pull Request を作成する際に使用するスキル。/pr create が呼び出されたときも含む。リポジトリの規約に従ってドラフト PR を作成します。
+description: A skill used when creating a Pull Request. This also applies when `/pr create` is invoked. It creates a draft PR according to the repository conventions.
 ---
 
 # pr-create
 
-## 概要
+## Overview
 
-ドラフトの Pull Request (PR) を作成するスキルです。
-ステージされたファイルやコミット済みの変更内容を理解し、適切なコミットメッセージと PR Description を作成して PR を作成します。
+This is a skill for creating a draft Pull Request (PR).
+It understands staged files and committed changes, then creates the PR with an appropriate commit message and PR description.
 
-## 使用タイミング
+## When to use
 
-- 「PR を作成して」と依頼されたとき
-- GitHub Copilot CLI で `/pr-create` や `/pr create` が呼び出されたとき
+- When asked to "create a PR"
+- When `/pr-create` or `/pr create` is invoked in GitHub Copilot CLI
 
-## 手順
+## Procedure
 
-### ステップ 1: 対応する Task (GitHub Issue) を確認する
+### Step 1: Check the corresponding Task (GitHub Issue)
 
-- まず最初に、この変更に対応する GitHub Issue (Task) があるかを確認する
-  - スキル呼び出し時のコンテキスト、ブランチ名、コミットメッセージなどから関連 Issue を推測する
-  - 推測できる場合は `gh issue view <番号> --comments` で内容を確認し、変更内容と整合しているか検証する
-    - Issue の Description だけでなくコメントも読み、変更の意図・経緯・議論の流れを把握する
-- 対応する Task が簡単に推測できない場合は、ユーザーに尋ねる
-  - 例: 「この変更に対応する Task (Issue) はありますか？ある場合は番号を教えてください」
-- 対応する Task が存在しない場合は、ユーザーに作成を促す
-  - Task を作成する場合は `gh issue create` を提案する
-  - Task を作成したら、その番号を控えておき、後続のステップ（PR Description の `closes #XXX`）で使用する
+- First, check whether there is a GitHub Issue (Task) corresponding to this change
+  - Infer the related issue from the context at skill invocation time, the branch name, commit messages, and so on
+  - If you can infer it, inspect it with `gh issue view <number> --comments` and verify that it matches the changes
+    - Read not only the issue description but also the comments to understand the intent, background, and flow of discussion
+- If the corresponding task cannot be inferred easily, ask the user
+  - Example: "Is there a Task (Issue) associated with this change? If so, please tell me the number."
+- If there is no corresponding task, encourage the user to create one
+  - If creating a task, suggest `gh issue create`
+  - After creating the task, note its number and use it in a later step (`closes #XXX` in the PR description)
 
-### ステップ 2: 変更内容を深く理解する
+### Step 2: Understand the changes deeply
 
-- `git diff --staged` または `git diff origin/main..` を実行し、差分全体を確認する
-- 各ファイルの差分を読み、**何が**・**なぜ**変更されたかを理解する
-  - 必ず origin/main に対してどのような変更が加わるのかにフォーカスすること
-- スキル呼び出し時に渡されたコンテキストや理由を考慮する
-- 変更内容や経緯を推測する際は、対応する Issue の Description やコメントも参考にすること
-- 新規ファイルの場合、ファイル全体を読んで目的と役割を把握する
-- 変更が複数の論理単位にまたがる場合、複数コミットへの分割を検討する
+- Run `git diff --staged` or `git diff origin/main..` and review the full diff
+- Read the diff for each file and understand **what** changed and **why**
+  - Always focus on what changes will be applied relative to `origin/main`
+- Consider the context and reasons provided when the skill was invoked
+- When inferring the change details or background, also refer to the corresponding issue description and comments
+- For new files, read the entire file to understand its purpose and role
+- If the changes span multiple logical units, consider splitting them into multiple commits
 
-### ステップ 3: コミットメッセージを作成してコミットする
+### Step 3: Create a commit message and commit
 
-- `git diff --staged --quiet` を実行し、終了コードが 1（ステージされたファイルあり）の場合のみコミットする
-- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 形式に従う
-- コミットメッセージは英語で書く
-- `git log --no-merges --oneline -100` で直近のコミットを確認し、リポジトリの慣習に合わせる
-- **コミットの件名は変更内容を具体的に記述すること**
-  - 悪い例: `docs: apply staged changes`（何が変わったか不明）
-  - 悪い例: `feat: update files`（曖昧すぎる）
-  - 良い例: `feat: allow provided config object to extend other configs`
-  - 良い例: `fix(github): pin terraform-provider-github version to 6.6.0`
-- scope は影響範囲を示す（ディレクトリ名、アクション名など）
-- 命令形（add, fix, update）を使い、意図を明確にする
-- 必要に応じて body に補足説明を追加する
-- レビューや論理的な分離に役立つ場合は複数コミットに分割してよい
+- Run `git diff --staged --quiet` and commit only when the exit code is 1 (meaning there are staged files)
+- Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
+- Write the commit message in English
+- Check recent commits with `git log --no-merges --oneline -100` and follow the repository conventions
+- **The commit subject must describe the change concretely**
+  - Bad example: `docs: apply staged changes` (unclear what changed)
+  - Bad example: `feat: update files` (too vague)
+  - Good example: `feat: allow provided config object to extend other configs`
+  - Good example: `fix(github): pin terraform-provider-github version to 6.6.0`
+- The scope indicates the affected area (such as a directory name or action name)
+- Use the imperative mood (`add`, `fix`, `update`) to make the intent clear
+- Add supplementary explanation in the body when needed
+- You may split the work into multiple commits if it helps reviewability or logical separation
 
-### ステップ 4: feature ブランチにプッシュする
+### Step 4: Push to a feature branch
 
-- 現在 main にいる場合は feature ブランチを作成してチェックアウトする
-- ブランチ名は変更内容を反映する（例: `feat/add-pr-create-skill`, `fix/pin-terraform-provider-github-660`）
-- `git push --set-upstream origin <branch>` でプッシュする
-- ローカルの main ブランチにコミットしてしまっている場合は、origin/main に合わせて元に戻す
+- If you are currently on `main`, create and check out a feature branch
+- The branch name should reflect the changes (for example, `feat/add-pr-create-skill`, `fix/pin-terraform-provider-github-660`)
+- Push with `git push --set-upstream origin <branch>`
+- If you accidentally committed on the local `main` branch, restore it to match `origin/main`
 
-### ステップ 5: PR Description を作成してドラフト PR を作る
+### Step 5: Create the PR description and open a draft PR
 
-- `.github/pull_request_template.md` が存在する場合、その構造に従うこと
-- PR 本文は日本語で記述すること
-- Description に含める内容:
-  - **目的:**
-    - この PR が達成すること（「何を」だけでなく「なぜ」も含める）
-    - ステップ 1 で確認・作成した Task がある場合は、`closes #XXX` を含めること
-  - **背景:**
-    - この変更が必要になった理由やコンテキスト
-    - 必ず origin/main に対してどのような変更がなされるのかにフォーカスして説明すること
-- `CONTRIBUTING.md` が存在する場合、そのガイドラインに従うこと
-- 以下のアンチパターンを避けること
-  - 「変更されたファイル」をそのまま列挙する（diff から明らかなことを書かない）
-  - 理由を示さない高コンテキストな説明
-- `gh pr create --draft` で PR を作成する
-  - **PR タイトル**は英語で、[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) 形式: `<type>(<scope>): <description>`
-  - PR 内容に適したラベルを設定する（例: `feature`, `bug`, `documentation`）
+- If `.github/pull_request_template.md` exists, follow its structure
+- Write the PR body in Japanese
+- Include the following in the description:
+  - **Purpose:**
+    - What this PR accomplishes, including not only **what** but also **why**
+    - If there is a task confirmed or created in Step 1, include `closes #XXX`
+  - **Background:**
+    - The reason or context that made this change necessary
+    - Be sure to explain it with a focus on what changes relative to `origin/main`
+- If `CONTRIBUTING.md` exists, follow its guidelines
+- Avoid the following anti-patterns
+  - Simply listing "changed files" as-is (do not write what is already obvious from the diff)
+  - High-context explanations that do not state the reason
+- Create the PR with `gh pr create --draft`
+  - The **PR title** must be in English and follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format: `<type>(<scope>): <description>`
+  - Set labels appropriate for the PR content (for example, `feature`, `bug`, `documentation`)
 
-### ステップ 6: リクエストしたユーザーをアサインする
+### Step 6: Assign the requesting user
 
-- スキルを呼び出したユーザーを PR の Assignee に設定する
-- `gh pr edit <PR_NUMBER> --add-assignee <username>` を使用する
+- Set the user who invoked the skill as the PR assignee
+- Use `gh pr edit <PR_NUMBER> --add-assignee <username>`
 
-### ステップ 7: Issue (Task) の Description を最終的な変更内容に合わせる
+### Step 7: Align the Issue (Task) description with the final changes
 
-- 対応する Task がある場合、その Description を最終的な Pull Request の変更内容に合わせた方針へ更新する
-- 試行錯誤の末、Issue の Description の方針と実際の変更内容が異なっていた場合:
-  - 当初の計画（元の Description）は `gh issue comment <番号>` でコメントとして切り出して残す
-  - その上で Issue の Description を `gh issue edit <番号> --body` で実際の変更内容に合わせた方針に更新する
-- Description と実際の変更内容が当初から一致している場合は、無理に書き換える必要はない
+- If there is a corresponding task, update its description so its plan matches the final pull request changes
+- If, after iteration, the issue description no longer matches the actual changes:
+  - Preserve the original plan (the original description) as a comment with `gh issue comment <number>`
+  - Then update the issue description with `gh issue edit <number> --body` so it reflects the actual changes
+- If the description and the actual changes matched from the start, there is no need to rewrite it unnecessarily
 
-## 出力
+## Output
 
-作成されたドラフト PR の URL をブラウザで開く。
+Open the URL of the created draft PR in the browser.

--- a/dotfiles/skills/pr-fix/SKILL.md
+++ b/dotfiles/skills/pr-fix/SKILL.md
@@ -1,58 +1,58 @@
 ---
-description: Pull Request を修正する際に使用するスキル。CI 失敗・レビューフィードバック・マージコンフリクトへの対処を行います。/pr fix、/pr fix all、/pr fix ci、/pr fix feedback、/pr fix conflicts が呼び出されたときも含む。
+description: A skill used when fixing a Pull Request. It handles CI failures, review feedback, and merge conflicts. This also applies when `/pr fix`, `/pr fix all`, `/pr fix ci`, `/pr fix feedback`, or `/pr fix conflicts` is invoked.
 name: pr-fix
 ---
 
 # pr-fix
 
-Pull Request をマージ可能な状態に導くスキルです。
+This is a skill for bringing a Pull Request into a mergeable state.
 
-## 使い方
+## Usage
 
-PR 番号と任意のモードを指定して呼び出します:
+Invoke it with a PR number and an optional mode:
 
 ```
-/pr fix #42              # すべて修正（conflicts → ci → feedback）
-/pr fix all #42          # 上記と同じ（明示的指定）
-/pr fix ci #42           # CI 失敗のみ修正
-/pr fix feedback #42     # レビューコメントのみ対処
-/pr fix conflicts #42    # マージコンフリクトのみ解消
+/pr fix #42              # Fix everything (conflicts → ci → feedback)
+/pr fix all #42          # Same as above (explicit mode)
+/pr fix ci #42           # Fix CI failures only
+/pr fix feedback #42     # Handle review comments only
+/pr fix conflicts #42    # Resolve merge conflicts only
 ```
 
-## モード
+## Modes
 
-### ci — CI 失敗の修正
+### ci — Fix CI failures
 
-- 指定された PR の CI ステータスを取得する
-- 失敗しているチェックがあればログを確認し、根本原因を特定する
-- すべての CI チェックが通るまで反復的に修正を適用する
-- CI がグリーンになったらコミット・プッシュする
-- 3 回試行しても CI 失敗を解消できない場合、作業を中止して問題を報告する
+- Retrieve the CI status for the specified PR
+- If any checks are failing, inspect the logs and identify the root cause
+- Apply fixes iteratively until all CI checks pass
+- Commit and push once CI is green
+- If the CI failures cannot be resolved after 3 attempts, stop the work and report the issue
 
-### conflicts — マージコンフリクトの解消
+### conflicts — Resolve merge conflicts
 
-- PR のベースブランチを fetch し、rebase またはマージでコンフリクトを表面化させる
-- コンフリクトが発生しているすべてのファイルを特定する
-- ベースブランチの変更が明らかに正しい場合を除き、PR の変更意図を保持しながら各コンフリクトを解消する
-- 解消したファイルを明確なメッセージでコミットする
-- 解消済みブランチをプッシュする
+- Fetch the PR base branch and surface conflicts through a rebase or merge
+- Identify all files with conflicts
+- Unless the base branch change is obviously correct, resolve each conflict while preserving the intent of the PR changes
+- Commit the resolved files with a clear message
+- Push the resolved branch
 
-### feedback — レビューコメントへの対処
+### feedback — Handle review comments
 
-- PR の未解決レビューコメントをすべて取得する
-  - 必ずレビューコメントへのリプライもすべて取得すること
-  - GraphQL でレビュースレッドを取得する際は `reviewThreads(first: 100, after: $cursor)` を使用し、レスポンスの `pageInfo { hasNextPage endCursor }` を確認すること
-  - `hasNextPage` が `true` の場合は `after: <endCursor>` で次ページを取得し、`hasNextPage` が `false` になるまで繰り返すこと
-- 各コメントについて、フィードバックの妥当性を評価する:
-  - **妥当** — 提案された修正・改善を適用する
-  - **妥当でない / 該当しない** — コードは変更せず、理由を説明するリプライを準備する
-- プッシュ後、各コメントに対してどのような対応を行ったかリプライする:
-  - 修正した場合: 行った変更を説明する
-  - 修正しなかった場合: 該当しないと判断した理由を説明する
-- リプライ送信後、レビューコメントのスレッドを resolve する
-- すべての対応が完了したら、Copilot Code Review にレビュー依頼をする
-  - PR の node ID を取得する: `gh pr view <PR_NUMBER> --json id -q .id`
-  - 取得した node ID を使って GraphQL mutation でレビュー依頼する:
+- Retrieve all unresolved review comments on the PR
+  - Be sure to retrieve all replies to the review comments as well
+  - When retrieving review threads via GraphQL, use `reviewThreads(first: 100, after: $cursor)` and inspect `pageInfo { hasNextPage endCursor }` in the response
+  - If `hasNextPage` is `true`, fetch the next page with `after: <endCursor>` and repeat until `hasNextPage` becomes `false`
+- For each comment, evaluate whether the feedback is valid:
+  - **Valid** — apply the proposed fix or improvement
+  - **Not valid / not applicable** — do not change the code; instead, prepare a reply explaining why
+- After pushing, reply to each comment describing how it was handled:
+  - If fixed: explain the changes that were made
+  - If not fixed: explain why it was judged not applicable
+- After sending replies, resolve the review comment threads
+- Once all responses are complete, request a review from Copilot Code Review
+  - Get the PR node ID: `gh pr view <PR_NUMBER> --json id -q .id`
+  - Use the retrieved node ID to request a review via a GraphQL mutation:
     ```
     gh api graphql -f query='
     mutation {
@@ -74,30 +74,30 @@ PR 番号と任意のモードを指定して呼び出します:
       }
     }'
     ```
-  - `BOT_kgDOCnlnWA` は `copilot-pull-request-reviewer` の GraphQL node ID
-  - REST API (`gh pr edit --add-reviewer`) では Bot は "not a collaborator" で弾かれるため使用不可
+  - `BOT_kgDOCnlnWA` is the GraphQL node ID for `copilot-pull-request-reviewer`
+  - The REST API (`gh pr edit --add-reviewer`) cannot be used because bots are rejected as "not a collaborator"
 
-### (default / all) — すべて修正
+### (default / all) — Fix everything
 
-モードが指定されない場合、または `all` が指定された場合、3 つのモードを順に実行する: **conflicts → ci → feedback**
+If no mode is specified, or if `all` is specified, run the three modes in order: **conflicts → ci → feedback**
 
-CI が正しく動作するためには、先にコンフリクトを解消する必要がある。
+Conflicts must be resolved first for CI to run correctly.
 
-## 共通ステップ（全モード共通）
+## Common steps (all modes)
 
-### プッシュ前のローカルレビュー
+### Local review before pushing
 
-- 変更をコミット・プッシュする前に、サブエージェント（`code-review` エージェントタイプ）を使用してローカルコードレビューを実行する
-- ローカルレビューで重大な問題がないことを確認してからコミット・プッシュする
+- Before committing and pushing changes, run a local code review using a sub-agent (the `code-review` agent type)
+- Confirm there are no significant issues in the local review before committing and pushing
 
-### PR Title・Description の更新
+### Update the PR title and description
 
-- 修正を行いプッシュした後、PR Title および Description が変更の現状を正確に反映するよう更新する
-- 更新前に必ず `gh pr view <PR_NUMBER>` で現在の Title・Description を取得し、その内容をベースに編集する（他の誰かが先に修正している可能性があるため）
-- `gh pr edit <PR_NUMBER> --title` および `gh pr edit <PR_NUMBER> --body` を使用して更新する
+- After making fixes and pushing, update the PR title and description so they accurately reflect the current state of the changes
+- Before updating, always retrieve the current title and description with `gh pr view <PR_NUMBER>` and edit based on that content, since someone else may have already updated them
+- Use `gh pr edit <PR_NUMBER> --title` and `gh pr edit <PR_NUMBER> --body` to apply the updates
 
-## 制約事項
+## Constraints
 
-- 必ず PR のブランチ上で作業する（変更前にブランチをチェックアウトする）
-- 論理的な修正ごとに 1 つのコミットとし、明確なメッセージを付ける
-- 明示的に指示されない限り force-push しない
+- Always work on the PR branch (check out the branch before making changes)
+- Make one commit per logical fix and use a clear message
+- Do not force-push unless explicitly instructed


### PR DESCRIPTION
## Purpose

Translated all documentation, comments, and skill definitions in the repository from Japanese to English.

closes #6

All code blocks, command names, file paths, URLs, and technical identifiers were preserved as-is. Only human-readable prose was translated.

## Background

The repository was originally written primarily in Japanese. To make it accessible to non-Japanese-speaking contributors and users, all `.md`, `.mdx`, and `.sh` files were translated to English.

Changes relative to `origin/main`:

- `README.md`, `.github/copilot-instructions.md`, `dotfiles/copilot-instructions.md`
- `docs/guides/` — all guide pages (01–06 + README)
- `docs/reference/` — all reference pages (16 files)
- `docs/development/` — contributor docs including ADRs (10 files)
- `dotfiles/skills/` — pr-create and pr-fix `SKILL.md`
- `docs/README.mdx`, `docs/issues/issue-1.md`

Post-translation verification confirmed zero Japanese characters remain across all affected files.