### PR TITLE
chore: translate docusaurus config navbar labels and i18n locale to English

### DIFF
--- a/.docusaurus/docusaurus.config.ts
+++ b/.docusaurus/docusaurus.config.ts
@@ -5,7 +5,7 @@ import remarkGithubAdmonitionsToDirectives from "remark-github-admonitions-to-di
 
 const config: Config = {
   title: "daiksud/dotfiles",
-  tagline: "macOS / Ubuntu 統一開発環境",
+  tagline: "macOS / Ubuntu Unified Development Environment",
   trailingSlash: false,
 
   future: {
@@ -22,8 +22,8 @@ const config: Config = {
   onBrokenLinks: "throw",
 
   i18n: {
-    defaultLocale: "ja",
-    locales: ["ja"],
+    defaultLocale: "en",
+    locales: ["en"],
   },
 
   presets: [
@@ -71,19 +71,19 @@ const config: Config = {
           type: "docSidebar",
           sidebarId: "guidesSidebar",
           position: "left",
-          label: "📖 ガイド",
+          label: "📖 Guides",
         },
         {
           type: "docSidebar",
           sidebarId: "referenceSidebar",
           position: "left",
-          label: "📋 リファレンス",
+          label: "📋 Reference",
         },
         {
           type: "docSidebar",
           sidebarId: "developmentSidebar",
           position: "left",
-          label: "🛠️ 開発",
+          label: "🛠️ Development",
         },
         {
           href: "https://github.com/daiksud/dotfiles",


### PR DESCRIPTION
## Purpose

This PR completes the translation of remaining Japanese text in the Docusaurus configuration.

Previously, PR #7 translated most documentation and comments to English, but the configuration UI labels and i18n settings remained in Japanese. This PR translates:

- Navbar labels (ガイド → Guides, リファレンス → Reference, 開発 → Development)
- Tagline (統一開発環境 → Unified Development Environment)
- i18n locale settings (defaultLocale and locales from ja to en)

This ensures all user-facing configuration text is now in English, providing a consistent English experience across the entire site.

## Background

Completing the full English translation improves consistency, discoverability, and accessibility for international users.