### PR TITLE
docs(pr-fix): add TDD workflow for bug/error feedback

### DIFF
--- a/dotfiles/skills/pr-fix/SKILL.md
+++ b/dotfiles/skills/pr-fix/SKILL.md
@@ -45,6 +45,10 @@ Invoke it with a PR number and an optional mode:
   - If `hasNextPage` is `true`, fetch the next page with `after: <endCursor>` and repeat until `hasNextPage` becomes `false`
 - For each comment, evaluate whether the feedback is valid:
   - **Valid** — apply the proposed fix or improvement
+    - If the feedback describes a specific case that causes an error or bug, apply fixes using TDD:
+      1. Write a unit test that reproduces the reported case
+      2. Confirm the unit test fails before making any code changes
+      3. Fix the code until the unit test passes
   - **Not valid / not applicable** — do not change the code; instead, prepare a reply explaining why
 - After pushing, reply to each comment describing how it was handled:
   - If fixed: explain the changes that were made


### PR DESCRIPTION
## Purpose

Add a TDD (Test-Driven Development) workflow to the `pr-fix` skill's `feedback` mode for cases where review comments describe a specific bug or error.

When feedback indicates "this case causes an error or bug", the skill now instructs the following three-step process before modifying code:

1. Write a unit test that reproduces the reported case
2. Confirm the unit test **fails** before making any code changes
3. Fix the code until the unit test passes

## Background

Previously, the `feedback` mode only distinguished between "Valid" and "Not valid" comments, with no specific guidance for bug reports. Fixing a reported bug without first writing a failing test risks:

- Misunderstanding the root cause and applying an incomplete fix
- Accidentally breaking the fix in future changes (no regression test)

By requiring a failing test first, the skill ensures reproducibility and prevents regressions.
