### PR TITLE
docs(pr-create): restrict feat/fix types to product-impacting changes only

### DIFF
--- a/dotfiles/skills/pr-create/SKILL.md
+++ b/dotfiles/skills/pr-create/SKILL.md
@@ -79,6 +79,7 @@ It understands staged files and committed changes, then creates the PR with an a
   - High-context explanations that do not state the reason
 - Create the PR with `gh pr create --draft`
   - The **PR title** must be in English and follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format: `<type>(<scope>): <description>`
+  - Use `feat` and `fix` **only** when the change directly affects the actual product (deliverable) — i.e., a new feature visible to end users or a bug fix that changes runtime behavior. Do **not** use `feat` or `fix` for changes that have no product impact, such as adding build tooling, fixing CI/CD configuration, or updating repository infrastructure. Use `build`, `ci`, `chore`, or another appropriate type instead.
   - Set labels appropriate for the PR content (for example, `feature`, `bug`, `documentation`)
 
 ### Step 6: Assign the requesting user


### PR DESCRIPTION
## Purpose

Add a rule to the `pr-create` skill clarifying when `feat` and `fix` Conventional Commits types may be used for PR titles and commit messages.

## Background

The `feat` and `fix` types were being used broadly, including for changes that have no impact on the actual product deliverable (e.g., build tooling, CI configuration, repository infrastructure). This can mislead readers of the changelog and version history into thinking product behavior changed when it did not.

This change adds an explicit rule: `feat` and `fix` are reserved for changes that directly affect the product — new user-facing features or bug fixes that alter runtime behavior. For everything else (`build`, `ci`, `chore`, etc.), the appropriate non-product type should be used instead.