### PR TITLE
feat(zsh): open per-application tmux sessions on terminal launch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,4 +72,5 @@ Style reference to read before editing:
 - Documentation must always state **what changed**, **why it changed**, and **how to operate it**
 - Make examples and commands ready to copy and use as-is
 - Avoid outdated guidance and duplicated guidance
+- **Never copy source code or configuration into documentation.** Reproducing real source or config files causes double maintenance and stale docs. Describe the behavior and link to the source file (for example, `dotfiles/zshrc`) instead. Only examples or sample snippets that are not maintained elsewhere belong in docs. See the "Source Code in Documentation" section of `docs/development/02-docs-style.md`
 - Include clear reasons in records of decisions

--- a/docs/development/02-docs-style.md
+++ b/docs/development/02-docs-style.md
@@ -78,6 +78,17 @@ graph LR
 
 - Do not prefix example commands with `$`
 
+## Source Code in Documentation
+
+Do not copy the project's real source code or configuration files into the documentation. Maintaining the same content in two places is costly and causes update omissions, where the documentation drifts out of sync with the implementation.
+
+- Describe **what** the code does and **why**, and link to the source file (for example, `dotfiles/zshrc` or `dotfiles/tmux.conf`) for the implementation itself
+- Only **examples** and **sample code** that are not maintained elsewhere may appear in documentation, such as a usage example, an illustrative command, or a minimal snippet that demonstrates a concept
+- When the implementation changes, you then only update the surrounding description instead of a duplicated copy of the code
+
+> [!IMPORTANT]
+> A code block that reproduces a real file under `dotfiles/` (or any other tracked source) is not allowed. Reference the file by path instead.
+
 ## Writing Japanese
 
 - Use polite Japanese style consistently (`desu/masu` style)

--- a/docs/development/99-adr/0006-per-app-tmux-sessions.md
+++ b/docs/development/99-adr/0006-per-app-tmux-sessions.md
@@ -1,0 +1,79 @@
+# ADR 0006: Per-application tmux sessions on terminal launch
+
+Group auto-started tmux sessions by terminal application instead of sharing a single `main` session.
+
+## Status
+
+Accepted
+
+## Context
+
+`.zshrc` auto-started tmux by attaching every shell to one hard-coded session:
+
+```zsh
+exec tmux new-session -A -s main
+```
+
+Because the name was always `main`, every terminal application — Ghostty, the
+VS Code integrated terminal, and any other emulator — attached to the **same**
+session. Opening a second window mirrored the first, so different applications
+could not keep independent layouts and working directories.
+
+The goal is to keep each terminal application in its own session while avoiding a
+buildup of orphaned, detached sessions.
+
+## Decision
+
+Derive the session from the terminal application, exposed through the
+`TERM_PROGRAM` environment variable, and reuse detached sessions before creating
+new ones.
+
+On shell startup (when not already inside tmux):
+
+1. Compute an app key from `${TERM_PROGRAM}`, lowercased and sanitized to
+   `[a-z0-9-]` (fallback `term` when unset).
+2. If a session of the same application is **detached**
+   (`#{session_attached}` is `0`), reattach to it.
+3. Otherwise create a new session named `<app>-<n>`, where `n` is the lowest free
+   index for that application.
+
+The logic lives in an anonymous function so its helper variables stay local, and
+`exec` replaces the shell with tmux as before. See
+[tmux reference](../../reference/tmux.md) for the full snippet.
+
+## Alternatives Considered
+
+### Keep a single shared `main` session
+
+Not adopted — it is exactly the behavior being replaced. Different applications
+cannot stay separate, and every window mirrors the same session.
+
+### One shared session per application (e.g. all Ghostty windows share `ghostty`)
+
+Considered — simpler than per-window sessions. Rejected because every window of
+the same application would still mirror one session, which prevents independent
+layouts per window.
+
+### Per-window unique session with no reuse
+
+Considered — give every window a brand-new session and never reattach. Rejected
+because closing and reopening windows would accumulate orphaned detached
+sessions over time.
+
+### Per-window unique session with detached reuse (chosen)
+
+Each window gets its own independent session, but a detached session of the same
+application is reattached first. This keeps windows independent while recycling
+freed sessions, so orphans do not pile up.
+
+## Consequences
+
+- Ghostty, VS Code, and other applications run in separate sessions named by app
+  (`ghostty-1`, `vscode-1`, …).
+- Each window is independent rather than a mirror of a shared session.
+- Detached sessions are recycled, so reopening a window reuses a freed session
+  instead of leaving an orphan.
+- The session name now depends on `TERM_PROGRAM`; terminals that do not set it
+  fall back to the `term` key.
+- Two windows opening at the exact same moment could both grab the same detached
+  session (mirroring them). This race is rare and accepted as-is.

--- a/docs/development/99-adr/0006-per-app-tmux-sessions.md
+++ b/docs/development/99-adr/0006-per-app-tmux-sessions.md
@@ -37,9 +37,10 @@ On shell startup (when not already inside tmux):
 3. Otherwise create a new session named `<app>-<n>`, where `n` is the lowest free
    index for that application.
 
-The logic lives in an anonymous function so its helper variables stay local, and
-`exec` replaces the shell with tmux as before. See
-[tmux reference](../../reference/tmux.md) for the full snippet.
+The implementation lives in `dotfiles/zshrc`; the helper logic is wrapped in a
+zsh anonymous function so its variables stay local, and `exec` replaces the shell
+with tmux as before. See the [tmux reference](../../reference/tmux.md) for a
+description of the resulting behavior.
 
 ## Alternatives Considered
 

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -15,6 +15,7 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 | [0003](./0003-sheldon-starship.md)   | Replace Oh-My-Zsh with Sheldon + Starship               | Accepted |
 | [0004](./0004-gh-q.md)               | Replace ghq with gh-q                                   | Accepted |
 | [0005](./0005-gh-infra.md)           | Manage repository settings declaratively with gh-infra  | Accepted |
+| [0006](./0006-per-app-tmux-sessions.md) | Per-application tmux sessions on terminal launch     | Accepted |
 
 ## How to Write a New ADR
 

--- a/docs/reference/tmux.md
+++ b/docs/reference/tmux.md
@@ -57,16 +57,51 @@ Managed by TPM (Tmux Plugin Manager). Plugin directory: `~/.tmux/plugins/`
 
 ## Auto-start
 
-In `.zshrc`, automatically connect to a tmux session:
+In `.zshrc`, automatically connect to a tmux session. Sessions are grouped by
+terminal application (read from `$TERM_PROGRAM`) so that Ghostty, VS Code, and
+other apps stay in separate sessions:
 
 ```zsh
 if [[ -z "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
-  exec tmux new-session -A -s main
+  () {
+    local app="${TERM_PROGRAM:-term}"
+    app="${app:l}"            # lowercase
+    app="${app//[^a-z0-9]/-}" # sanitize to [a-z0-9-]
+    local target
+    target=$(tmux list-sessions -F '#{session_attached} #{session_name}' 2>/dev/null \
+      | awk -v a="$app" '$1 == 0 && $2 ~ ("^" a "(-|$)") { print $2; exit }')
+    if [[ -n "$target" ]]; then
+      exec tmux attach-session -t "$target"
+    fi
+    local n=1
+    while tmux has-session -t "${app}-${n}" 2>/dev/null; do
+      (( n++ ))
+    done
+    exec tmux new-session -s "${app}-${n}"
+  }
 fi
 ```
 
-- `new-session -A -s main` — Attach if the `main` session exists; otherwise create it
-- `exec` — Replace the shell with tmux (the terminal closes when tmux exits)
+How it works:
+
+- **App key** — `$TERM_PROGRAM` is lowercased and sanitized to `[a-z0-9-]`
+  (`Ghostty` → `ghostty`, `vscode` → `vscode`, `Apple_Terminal` →
+  `apple-terminal`). It falls back to `term` when `$TERM_PROGRAM` is unset.
+- **Reattach a detached session** — `tmux list-sessions` reports each session's
+  attached client count. If a session named `<app>` or `<app>-<n>` has no client
+  attached (`#{session_attached}` is `0`), the shell reattaches to it. Only
+  sessions of the same application are considered.
+- **Otherwise start a new session** — when every same-app session is already
+  attached (or none exist), a new session is created at the lowest free index,
+  for example `ghostty-1`, then `ghostty-2`.
+- **Anonymous function `() { ... }`** — keeps the helper variables local without
+  declaring `local` at file scope.
+- **`exec`** — replaces the shell with tmux (the terminal closes when tmux exits).
+
+> [!NOTE]
+> Each window gets its own independent session rather than mirroring a shared
+> one. Detached sessions are recycled first, so closing and reopening a window
+> reuses the freed session instead of leaving an orphan behind.
 
 ## Initializing TPM
 

--- a/docs/reference/tmux.md
+++ b/docs/reference/tmux.md
@@ -57,46 +57,24 @@ Managed by TPM (Tmux Plugin Manager). Plugin directory: `~/.tmux/plugins/`
 
 ## Auto-start
 
-In `.zshrc`, automatically connect to a tmux session. Sessions are grouped by
-terminal application (read from `$TERM_PROGRAM`) so that Ghostty, VS Code, and
-other apps stay in separate sessions:
-
-```zsh
-if [[ -z "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
-  () {
-    local app="${TERM_PROGRAM:-term}"
-    app="${app:l}"            # lowercase
-    app="${app//[^a-z0-9]/-}" # sanitize to [a-z0-9-]
-    local target
-    target=$(tmux list-sessions -F '#{session_attached} #{session_name}' 2>/dev/null \
-      | awk -v a="$app" '$1 == 0 && $2 ~ ("^" a "(-|$)") { print $2; exit }')
-    if [[ -n "$target" ]]; then
-      exec tmux attach-session -t "$target"
-    fi
-    local n=1
-    while tmux has-session -t "${app}-${n}" 2>/dev/null; do
-      (( n++ ))
-    done
-    exec tmux new-session -s "${app}-${n}"
-  }
-fi
-```
+When a shell starts, `.zshrc` connects it to a tmux session automatically.
+Sessions are grouped by terminal application (read from `$TERM_PROGRAM`) so that
+Ghostty, VS Code, and other apps stay in separate sessions. The implementation
+lives in `dotfiles/zshrc`.
 
 How it works:
 
 - **App key** — `$TERM_PROGRAM` is lowercased and sanitized to `[a-z0-9-]`
   (`Ghostty` → `ghostty`, `vscode` → `vscode`, `Apple_Terminal` →
   `apple-terminal`). It falls back to `term` when `$TERM_PROGRAM` is unset.
-- **Reattach a detached session** — `tmux list-sessions` reports each session's
-  attached client count. If a session named `<app>` or `<app>-<n>` has no client
-  attached (`#{session_attached}` is `0`), the shell reattaches to it. Only
-  sessions of the same application are considered.
+- **Reattach a detached session** — if a session of the same application has no
+  client attached, the shell reattaches to it instead of creating a new one.
+  Sessions of other applications are never reused.
 - **Otherwise start a new session** — when every same-app session is already
   attached (or none exist), a new session is created at the lowest free index,
   for example `ghostty-1`, then `ghostty-2`.
-- **Anonymous function `() { ... }`** — keeps the helper variables local without
-  declaring `local` at file scope.
-- **`exec`** — replaces the shell with tmux (the terminal closes when tmux exits).
+- **Replace the shell** — the shell process is replaced with tmux, so the
+  terminal closes when tmux exits.
 
 > [!NOTE]
 > Each window gets its own independent session rather than mirroring a shared
@@ -105,10 +83,7 @@ How it works:
 
 ## Initializing TPM
 
-Start TPM after prepending the Homebrew path:
-
-```
-run 'PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH" ~/.tmux/plugins/tpm/tpm'
-```
-
-This allows TPM's plugin scripts to use Homebrew's bash 5+.
+TPM is initialized at the bottom of `tmux.conf`. The Homebrew paths
+(`/opt/homebrew/bin`, `/opt/homebrew/sbin`) are prepended before TPM runs so that
+its plugin scripts can find Homebrew's bash 5+ via `env(1)`. See
+`dotfiles/tmux.conf` for the exact line.

--- a/docs/reference/zsh/README.md
+++ b/docs/reference/zsh/README.md
@@ -48,8 +48,6 @@ This is the reference for Zsh shell configuration.
 
 ## Completion style
 
-```zsh
-zstyle ':completion:*' matcher-list 'm:{a-zA-Z-_}={A-Za-z_-}'
-```
-
-Complete without distinguishing uppercase/lowercase and hyphen/underscore.
+Completion matches without distinguishing uppercase/lowercase or
+hyphen/underscore. This is configured with a `zstyle` `matcher-list` rule in
+`dotfiles/zshrc`.

--- a/docs/reference/zsh/README.md
+++ b/docs/reference/zsh/README.md
@@ -13,7 +13,7 @@ This is the reference for Zsh shell configuration.
 
 `.zshrc` is processed in the following order:
 
-1. **Auto-start tmux** — Connect to or create a tmux session
+1. **Auto-start tmux** — Connect to or create a per-application tmux session
 2. **Homebrew** — Set shell environment variables
 3. **compinit** — Initialize the completion system (must come before sheldon)
 4. **Emacs keybindings** — `bindkey -e`

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -1,6 +1,24 @@
-# Auto-attach or create tmux session (exit shell when tmux exits)
+# Auto-attach or create a per-application tmux session (exit shell when tmux exits).
+# Sessions are grouped by terminal application via $TERM_PROGRAM so that Ghostty,
+# VS Code, etc. stay separate. Reattach to a detached session of the same app if
+# one exists; otherwise start a new uniquely named "<app>-<n>" session.
 if [[ -z "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
-  exec tmux new-session -A -s main
+  () {
+    local app="${TERM_PROGRAM:-term}"
+    app="${app:l}"            # lowercase
+    app="${app//[^a-z0-9]/-}" # sanitize to [a-z0-9-]
+    local target
+    target=$(tmux list-sessions -F '#{session_attached} #{session_name}' 2>/dev/null \
+      | awk -v a="$app" '$1 == 0 && $2 ~ ("^" a "(-|$)") { print $2; exit }')
+    if [[ -n "$target" ]]; then
+      exec tmux attach-session -t "$target"
+    fi
+    local n=1
+    while tmux has-session -t "${app}-${n}" 2>/dev/null; do
+      (( n++ ))
+    done
+    exec tmux new-session -s "${app}-${n}"
+  }
 fi
 
 # Homebrew


### PR DESCRIPTION
## Purpose

Make terminals attach to a separate tmux session per application when opened. This resolves the current situation where different applications such as Ghostty and VS Code share the same session and mirror each other, so each app and each window can keep an independent working state.

closes #15

## Background

On `origin/main`, `dotfiles/zshrc` attaches every shell to a hard-coded session named `main` on startup, so every terminal shares the same session regardless of `$TERM_PROGRAM`. As a result, the second and later windows mirror the first and cannot keep state independent per app or window.

This PR changes the startup logic as follows:

- Derive an app key from `$TERM_PROGRAM` (lowercased and sanitized to `[a-z0-9-]`, falling back to `term` when unset).
- If a detached session of the same application exists, reattach to it.
- Otherwise, create a new `<app>-<n>` session at the lowest free index.
- Keep the logic locally scoped in a zsh anonymous function, preserving the existing `exec` and `[[ -z "$TMUX" ]]` guard.

With this, Ghostty becomes `ghostty-1` / `ghostty-2` …, VS Code becomes `vscode-1` …, and each window stays independent while detached sessions are reused first, so orphaned sessions do not accumulate.

Code and docs are kept in sync as well:

- `docs/reference/tmux.md`: Rewrote the Auto-start section to describe the new behavior (no source copy).
- `docs/reference/zsh/README.md`: Updated item 1 of the `.zshrc` structure to a per-application session.
- `docs/development/99-adr/0006-per-app-tmux-sessions.md`: Recorded the decision and the alternatives considered, and added it to the ADR index.

## Documentation policy: no source-code duplication

While writing the docs above, the Auto-start section had copied the real `zshrc` implementation verbatim, which is double maintenance and drifts out of sync. This PR adds a policy against it and applies it to the touched docs:

- `.github/copilot-instructions.md` and `docs/development/02-docs-style.md`: Added a rule that documentation must not reproduce real source or configuration files. Describe the behavior and link to the source file; only examples and sample snippets that are not maintained elsewhere are allowed.
- Removed the verbatim `zshrc` / `tmux.conf` snippets from `docs/reference/tmux.md` and `docs/reference/zsh/README.md`, replacing them with descriptions that point to the source files.

A repo-wide sweep of other reference docs (sheldon, starship, mise, nvim, …) that still embed config fragments is tracked separately as a follow-up.

## Verification

- `zsh -n dotfiles/zshrc` syntax check: OK
- Logic test with a mocked `tmux`: 10/10 cases passed (reattach / new session / index assignment / same-app only / `Apple_Terminal` and `iTerm.app` sanitization / fallback when unset)
- `bun run docs:build`: succeeded (no broken links)