### PR TITLE
docs(pr-create): add GFM guidance for PR body authoring

### DIFF
--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -117,7 +117,7 @@ name: Skill name
 2. Understand the changes with `git diff` (also refer to the Issue description and comments)
 3. Commit using the Conventional Commits format
 4. Push to the feature branch
-5. Create the PR description (write the body in Japanese), then create a draft PR with `gh pr create --draft`
+5. Create the PR description (write a readable, visually clear body that fully leverages GFM features such as tables, alerts, Mermaid, and emoji), then create a draft PR with `gh pr create --draft`
 6. Set the invoking user as the Assignee
 7. Finally, update the corresponding Task description to match the final changes (move the original plan to a comment)
 

--- a/dotfiles/skills/pr-create/SKILL.md
+++ b/dotfiles/skills/pr-create/SKILL.md
@@ -69,6 +69,13 @@ It understands staged files and committed changes, then creates the PR with an a
 
 - If `.github/pull_request_template.md` exists, follow its structure
 - Write the PR body in English
+- **Make full use of GitHub Flavored Markdown (GFM) features** so the body is readable, visually clear, and engaging:
+  - **Tables** to organize structured information such as comparisons, before/after, or summaries of changes
+  - **Alerts** (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) to highlight key points, caveats, and breaking changes
+  - **Mermaid diagrams** to visualize flows, architecture, sequences, or relationships
+  - **Emoji** to add visual cues and make sections easy to scan
+  - Other GFM elements (task lists, collapsible `<details>`, code blocks with language hints, etc.) wherever they aid comprehension
+  - Do not decorate for its own sake — use each element only when it genuinely improves clarity
 - Include the following in the description:
   - **Purpose:**
     - What this PR accomplishes, including not only **what** but also **why**


### PR DESCRIPTION
## ✨ Purpose

> [!IMPORTANT]
> This PR updates the `pr-create` skill so generated PR descriptions are **more readable, visually clear, and engaging** by actively using GitHub Flavored Markdown (GFM).

| Area | Change | Why it matters |
| --- | --- | --- |
| `dotfiles/skills/pr-create/SKILL.md` | Added explicit instruction to fully use GFM features in PR bodies | Improves consistency and review experience |
| `docs/reference/skills.md` | Updated workflow summary for Step 5 to match current behavior | Keeps reference docs aligned with implementation |

## 🧭 Background

> [!NOTE]
> The skill recently standardized PR-body guidance in English. This change clarifies **how** to structure PR content (not just language), focusing on communication quality relative to `origin/main`.

```mermaid
flowchart LR
  A[Old guidance\nWrite PR body in English] --> B[New guidance\nUse GFM intentionally]
  B --> C[Better scanability]
  B --> D[Clear risk/context signaling]
  B --> E[More effective reviews]
```

## ✅ GFM expectations added

- [x] Tables for structured comparisons and summaries
- [x] Alerts for key notes/warnings
- [x] Mermaid for flow/relationship visualization
- [x] Emoji for scan-friendly section cues
- [x] Additional GFM elements when they improve comprehension

<details>
<summary>📌 Non-goals</summary>

- Decorative formatting without informational value
- Repeating obvious file-level diffs without context

</details>
