### PR TITLE
docs(pr-fix): add "will not address" reply handling to feedback mode

### DIFF
--- a/docs/guides/06-skills.md
+++ b/docs/guides/06-skills.md
@@ -50,7 +50,7 @@ In an interactive session, you can also start it with `/pr fix` (described later
 
 1. Detects and resolves merge conflicts
 2. Identifies CI failures from logs and fixes them (repeating until they pass)
-3. Checks review comments and applies reasonable fixes
+3. Checks review comments and applies reasonable fixes (any comment you reply "対応しない" to is left unchanged, and the reason is recorded in the PR body)
 4. Performs a local review before pushing
 5. Replies to each review comment with what was addressed and resolves the thread
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -137,7 +137,7 @@ name: Skill name
 1. Check the CI status of the specified PR
 2. If there are CI failures, analyze the logs and repeat fixes (up to 3 times)
 3. Retrieve all review comments and judge the validity of each one
-4. Fix valid comments and skip invalid ones
+4. Fix valid comments and skip invalid ones; for comments the user replied "対応しない" (will not address) to, record in the PR body that they will not be addressed along with the reason
 5. Before committing and pushing, run a local review with the `code-review` sub-agent
 6. After pushing, reply to each review comment with how it was addressed
 

--- a/dotfiles/copilot-instructions.md
+++ b/dotfiles/copilot-instructions.md
@@ -8,33 +8,3 @@ If the user runs `/pr fix` or asks to fix, improve, or make a Pull Request merge
 ## Comments on Issues / Pull Requests
 
 When posting a comment or reply on an Issue or Pull Request at the user's instruction, always prefix it with `:robot:`.
-
-<!-- rtk-instructions v2 -->
-
-# RTK — Token-Optimized CLI
-
-**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
-
-## Rule
-
-Always prefix shell commands with `rtk`:
-
-```bash
-# Instead of:              Use:
-git status                 rtk git status
-git log -10                rtk git log -10
-cargo test                 rtk cargo test
-docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl pods
-```
-
-## Meta commands (use directly)
-
-```bash
-rtk gain              # Token savings dashboard
-rtk gain --history    # Per-command savings history
-rtk discover          # Find missed rtk opportunities
-rtk proxy <cmd>       # Run raw (no filtering) but track usage
-```
-
-<!-- /rtk-instructions -->

--- a/dotfiles/skills/pr-fix/SKILL.md
+++ b/dotfiles/skills/pr-fix/SKILL.md
@@ -43,6 +43,7 @@ Invoke it with a PR number and an optional mode:
   - Be sure to retrieve all replies to the review comments as well
   - When retrieving review threads via GraphQL, use `reviewThreads(first: 100, after: $cursor)` and inspect `pageInfo { hasNextPage endCursor }` in the response
   - If `hasNextPage` is `true`, fetch the next page with `after: <endCursor>` and repeat until `hasNextPage` becomes `false`
+- If a comment thread contains a reply from the user stating it will not be addressed (for example, "対応しない"), do not change the code for that comment and skip the validity evaluation below. Instead, append to the PR body that the comment will not be addressed, together with the reason the user gave.
 - For each comment, evaluate whether the feedback is valid:
   - **Valid** — apply the proposed fix or improvement
     - If the feedback describes a specific case that causes an error or bug, apply fixes using TDD:
@@ -53,6 +54,7 @@ Invoke it with a PR number and an optional mode:
 - After pushing, reply to each comment describing how it was handled:
   - If fixed: explain the changes that were made
   - If not fixed: explain why it was judged not applicable
+  - If the user decided not to address it: note that it will not be addressed and that the reason is recorded in the PR body
 - After sending replies, resolve the review comment threads
 - Once all responses are complete, request a review from Copilot Code Review
   - Get the PR node ID: `gh pr view <PR_NUMBER> --json id -q .id`


### PR DESCRIPTION
## 📋 Purpose

Extend the `pr-fix` skill's **feedback** mode to handle review comments where the user has explicitly replied that they will not address the feedback.

Previously, the skill only distinguished between *valid* feedback (apply a fix) and *not applicable* feedback (reply with a reason). There was no path for comments the **user** themselves decided to skip with a reply like `"対応しない"`.

## 🔍 Background

During real-world use, users sometimes reply `"対応しない"` (will not address) on a review thread to record their decision. The previous skill instructions did not account for this case, meaning:

- The agent might incorrectly evaluate such threads as "invalid feedback" and just reply with a technical reason
- The PR body never reflected which comments were intentionally skipped and why

## ✅ Changes

### `dotfiles/skills/pr-fix/SKILL.md`

| Area | Before | After |
|------|--------|-------|
| Comment classification | Valid / Not applicable | Valid / Not applicable / **User decided not to address** |
| Handling "対応しない" reply | Not described | Skip validity eval → append reason to PR body |
| Reply guidance | Fixed / Not fixed | Fixed / Not fixed / **Will not address (reason in PR body)** |

### Docs (`docs/reference/skills.md`, `docs/guides/06-skills.md`)

Updated to reflect the new behaviour in the workflow summary and user-facing guide.

---

> [!NOTE]
> Also includes a separate cleanup commit removing an injected `rtk-instructions` block from `dotfiles/copilot-instructions.md` that was no longer needed.
