### PR TITLE
fix(zsh): guard tmux auto-launch against non-TTY shells

### DIFF
--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -2,7 +2,14 @@
 # Sessions are grouped by terminal application via $TERM_PROGRAM so that Ghostty,
 # VS Code, etc. stay separate. Reattach to a detached session of the same app if
 # one exists; otherwise start a new uniquely named "<app>-<n>" session.
-if [[ -z "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
+#
+# Only run for a real interactive terminal. Skip when stdout is not a tty or when
+# VS Code is resolving the shell environment (it spawns a non-tty login+interactive
+# shell). Otherwise `exec tmux` hijacks that probe, tmux fails with "not a terminal",
+# and VS Code reports "Unable to resolve your shell environment".
+if [[ -z "$TMUX" ]] && [[ -o interactive ]] && [[ -t 1 ]] \
+   && [[ -z "$VSCODE_RESOLVING_ENVIRONMENT" ]] \
+   && command -v tmux >/dev/null 2>&1; then
   () {
     local app="${TERM_PROGRAM:-term}"
     app="${app:l}"            # lowercase


### PR DESCRIPTION
## Purpose

Guard the tmux auto-launch block in `.zshrc` so it only runs in a real interactive terminal. This fixes VS Code's startup notification:

```
Unable to resolve your shell environment: Unexpected exit code from spawned shell (code 1, signal null)
```

closes #20

## Background

PR #16 introduced per-application tmux sessions by unconditionally running `exec tmux` at shell startup. VS Code spawns a **non-TTY login+interactive shell** to collect environment variables at startup. In that context:

1. The tmux block runs and calls `exec tmux`
2. tmux exits with `open terminal failed: not a terminal` (no TTY available)
3. The shell exits with code 1 — VS Code cannot read the environment and shows the error

## What changed

Three additional guards were added to the `if` condition before the tmux block:

| Guard | What it checks |
|---|---|
| `[[ -o interactive ]]` | Shell is interactive (already present implicitly, now explicit) |
| `[[ -t 1 ]]` | Stdout is a real TTY — skips pipes and VS Code's env probe |
| `[[ -z "$VSCODE_RESOLVING_ENVIRONMENT" ]]` | Explicitly skips VS Code's environment resolution shell |

> [!NOTE]
> Normal terminal usage (Ghostty, VS Code integrated terminal, etc.) is **unaffected** — those always have a TTY and do not set `VSCODE_RESOLVING_ENVIRONMENT`.

## Verification

Reproduced VS Code's env-probe pattern and confirmed `exit=0` after the fix:

```zsh
env -u TMUX VSCODE_RESOLVING_ENVIRONMENT=1 zsh -lic 'print -r -- ENV_RESOLVED_OK'
# → ENV_RESOLVED_OK  (exit 0, tmux not launched)
```