### PR TITLE
feat(gh-wt): add gh-wt extension, skill, and worktree shortcut

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,7 @@ Under `docs/`, place GitHub Flavored Markdown documentation built with Docusauru
 | Zsh plugins        | `docs/reference/zsh/plugins.md`             | Users        |
 | install_map.json   | `docs/reference/install-map.md`             | Users        |
 | gh-infra           | `docs/reference/gh-infra.md`                | Users        |
+| gh-wt              | `docs/reference/gh-wt.md`                   | Users        |
 | Scripts            | `docs/reference/scripts.md`                 | Users        |
 | Tools (Brewfile)   | `docs/reference/tools.md`                   | Users        |
 | Copilot Skills     | `docs/reference/skills.md`                  | Users        |

--- a/docs/development/99-adr/0007-gh-wt.md
+++ b/docs/development/99-adr/0007-gh-wt.md
@@ -1,0 +1,80 @@
+# ADR 0007: Manage git worktrees with gh-wt
+
+Adopt the `gh-wt` GitHub CLI extension for copy-on-write (CoW) backed git worktrees instead of plain `git worktree add`.
+
+## Status
+
+Accepted
+
+## Context
+
+Several workflows in this repository benefit from running more than one working
+tree of the same repository at once: parallel agent sessions, side-by-side PR
+review, and benchmarking changes across branches. `git worktree add` supports
+this natively, but it copies every tracked file into each new worktree, which
+has real costs once more than a couple of worktrees are in use:
+
+- Disk usage grows linearly with each worktree, since nothing is shared with
+  the source checkout
+- Creating a worktree is slow, because every file has to be copied rather than
+  shared
+- Neither Linux nor macOS's default worktree path uses copy-on-write, so this
+  cost cannot be avoided through configuration alone
+- There is no built-in way to interactively pick an existing worktree; the
+  user has to remember or look up exact paths and branch names
+
+## Decision
+
+Adopt `gh-wt` (`HikaruEgashira/gh-wt`) to create and manage git worktrees
+backed by copy-on-write.
+
+- Install it with `gh extension install` in `scripts/100-gh-extensions.sh`,
+  alongside `gh-q` and `gh-infra`
+- Back worktrees with OverlayFS on Linux and APFS `clonefile(2)` on macOS, so
+  a new worktree shares disk blocks with the source checkout until it diverges
+- Operate it through `gh wt list`, `gh wt add [--new|-b] <branch> [path]`,
+  `gh wt remove [target]`, `gh wt gc`, and `gh wt [--at <wt>] <command>` to
+  run a command against a worktree
+- Fall back to `fzf` for interactive worktree selection whenever a command
+  needs a target and none is given
+- Expose it to agent workflows through the `dotfiles/skills/gh-wt/` Copilot
+  CLI skill (generated with `gh skill install HikaruEgashira/gh-wt gh-wt`)
+- Expose it to interactive shell use through the `gwt` zsh shortcut
+  (`go-to-worktree`, in `dotfiles/zsh/go-to-worktree.zsh`), which fzf-selects
+  a worktree and `cd`s into it
+
+## Alternatives Considered
+
+### Plain `git worktree add`
+
+Works everywhere without extra tooling, but every worktree is a full copy of
+the tracked files — disk usage grows linearly and creation is slow at scale
+(upstream benchmarks show roughly 8x more disk at 10 worktrees and 13x at 20,
+compared to a CoW-backed worktree). It also has no interactive picker, so
+entering or removing a worktree means remembering exact paths or branch names.
+Not adopted as the primary workflow, though it remains available as the
+underlying git command.
+
+### ghq / gh-q
+
+Already adopted in this repository (ADR 0004) for managing where local clones
+of *different* repositories live on disk. It does not address concurrent
+worktrees of the *same* repository, so it solves a different problem and does
+not replace the need for a worktree-focused tool.
+
+## Consequences
+
+- `fzf` becomes a soft prerequisite for the interactive picker; it is already
+  a Brewfile dependency, so no new dependency is introduced
+- On macOS, the worktree target path and gh-wt's cache directory must sit on
+  the same APFS volume, or `clonefile(2)` fails with `apfs clone failed`; set
+  `GH_WT_CACHE_DIR` to a path on the same volume when this occurs
+- `gh wt add` refuses to create a branch that doesn't exist locally or on
+  origin unless `--new`/`-b` (or `GH_WT_ASSUME_NEW=1`) is passed
+- The `fzf` picker is skipped when there is only one candidate, when `--at`
+  pins the target, or when `GH_WT_NONINTERACTIVE=1` is set, which keeps
+  CI and agent-driven shells non-interactive
+- Requires GitHub CLI v2.90.0 or later, and either Linux kernel 5.11+
+  (OverlayFS) or macOS (APFS); systems without either fall back to whatever
+  `gh-wt` does natively, without CoW benefits
+- Operational guidance is documented in [reference/gh-wt.md](../../reference/gh-wt.md)

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -8,14 +8,15 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 
 ## ADR List
 
-| ID                                   | Title                                                   | Status   |
-| ------------------------------------ | ------------------------------------------------------- | -------- |
-| [0001](./0001-json-install-map.md)   | Adopt a JSON mapping table for symbolic link management | Accepted |
-| [0002](./0002-ssh-commit-signing.md) | Adopt SSH commit signing                                | Accepted |
-| [0003](./0003-sheldon-starship.md)   | Replace Oh-My-Zsh with Sheldon + Starship               | Accepted |
-| [0004](./0004-gh-q.md)               | Replace ghq with gh-q                                   | Accepted |
-| [0005](./0005-gh-infra.md)           | Manage repository settings declaratively with gh-infra  | Accepted |
-| [0006](./0006-per-app-tmux-sessions.md) | Per-application tmux sessions on terminal launch     | Accepted |
+| ID                                      | Title                                                   | Status   |
+| --------------------------------------- | ------------------------------------------------------- | -------- |
+| [0001](./0001-json-install-map.md)      | Adopt a JSON mapping table for symbolic link management | Accepted |
+| [0002](./0002-ssh-commit-signing.md)    | Adopt SSH commit signing                                | Accepted |
+| [0003](./0003-sheldon-starship.md)      | Replace Oh-My-Zsh with Sheldon + Starship               | Accepted |
+| [0004](./0004-gh-q.md)                  | Replace ghq with gh-q                                   | Accepted |
+| [0005](./0005-gh-infra.md)              | Manage repository settings declaratively with gh-infra  | Accepted |
+| [0006](./0006-per-app-tmux-sessions.md) | Per-application tmux sessions on terminal launch        | Accepted |
+| [0007](./0007-gh-wt.md)                 | Manage git worktrees with gh-wt                         | Accepted |
 
 ## How to Write a New ADR
 

--- a/docs/guides/06-skills.md
+++ b/docs/guides/06-skills.md
@@ -9,10 +9,11 @@ This is a guide for getting started quickly with custom Copilot CLI skills.
 
 ## Available skills
 
-| Skill       | What it does                                                                        |
-| ----------- | ----------------------------------------------------------------------------------- |
-| `pr-create` | Automatically creates a draft PR from the current changes                           |
-| `pr-fix`    | Fixes CI errors, handles reviews, and resolves merge conflicts for the specified PR |
+| Skill       | What it does                                                                              |
+| ----------- | ----------------------------------------------------------------------------------------- |
+| `pr-create` | Automatically creates a draft PR from the current changes                                 |
+| `pr-fix`    | Fixes CI errors, handles reviews, and resolves merge conflicts for the specified PR       |
+| `gh-wt`     | Creates and manages CoW-backed git worktrees (list/add/remove/gc) via the gh-wt extension |
 
 ## Use `pr-create`
 
@@ -61,6 +62,46 @@ copilot -p "/pr-fix ci #42"        # CI failures only
 copilot -p "/pr-fix feedback #42"  # Review comments only
 copilot -p "/pr-fix conflicts #42" # Conflicts only
 ```
+
+## Use `gh-wt`
+
+Unlike `pr-create` and `pr-fix`, `gh-wt` is not a hand-authored skill and has no slash command. It was
+installed straight from the upstream repository with `gh skill install HikaruEgashira/gh-wt gh-wt`, and
+Copilot triggers it automatically whenever your prompt matches its purpose — just describe what you want
+in natural language:
+
+```bash
+copilot -p "create a worktree for feature-x"
+copilot -p "run the tests in a clean worktree without touching my current changes"
+copilot -p "open PR #123 side-by-side with main"
+```
+
+Phrasing such as "spin up a fresh copy of branch X", "run claude in a clean checkout", or "try this patch
+without touching my changes" also triggers the skill, even when the word "worktree" is never said.
+
+### What happens
+
+1. Selects an existing worktree or creates a new one via `gh wt`
+2. Runs the command you asked for inside that worktree, or reports its path if you only asked to create
+   or list one
+
+### Prerequisite
+
+The skill wraps the `gh wt` extension, so it must be installed once with:
+
+```bash
+gh extension install HikaruEgashira/gh-wt
+```
+
+In this repository, `install.sh` already installs it for you via `scripts/100-gh-extensions.sh`, so no
+manual step is normally required.
+
+See the [gh-wt reference](../reference/gh-wt.md) for the full command list (`gh wt add`, `list`, `remove`,
+`gc`, and more).
+
+> [!NOTE]
+> Prefer a plain shell shortcut over an AI round-trip? The `gwt` function fzf-selects a worktree and `cd`s
+> into it directly, without going through Copilot. See [zsh plugins](../reference/zsh/plugins.md) for details.
 
 ## Integration with `/pr create` and `/pr fix`
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -22,6 +22,7 @@ a detailed reference for the dotfiles configuration files, tool list, and struct
 ## Infrastructure
 
 - [gh-infra](./gh-infra.md) — Declarative repository settings management with `.github/settings.yml`
+- [gh-wt](./gh-wt.md) — Fast, disk-efficient git worktrees with the gh-wt GitHub CLI extension
 - [install_map.json](./install-map.md) — Specification for the symbolic link mapping table
 - [Script list](./scripts.md) — The role of each script under `scripts/`
 - [Tool list](./tools.md) — Tools managed in the Brewfile and their purposes

--- a/docs/reference/gh-wt.md
+++ b/docs/reference/gh-wt.md
@@ -1,0 +1,79 @@
+# gh-wt
+
+This is the reference for fast, disk-efficient git worktrees with the `gh-wt` GitHub CLI extension.
+
+## Overview
+
+[gh-wt](https://github.com/HikaruEgashira/gh-wt) (`HikaruEgashira/gh-wt`) is a GitHub CLI extension for creating and managing git worktrees backed by copy-on-write (CoW): OverlayFS on Linux, and APFS `clonefile(2)` on macOS.
+
+Plain `git worktree add` copies every tracked file into each new worktree, so disk usage grows linearly and creation gets slower as more worktrees are added. `gh-wt` instead shares disk blocks with the source checkout until files diverge. Upstream benchmarks show roughly 8x less disk usage at 10 concurrent worktrees, and 13x less at 20, compared to plain worktrees.
+
+## Setup
+
+The `gh-wt` extension is installed automatically by `scripts/100-gh-extensions.sh` (see [Script list](./scripts.md)). To install it manually:
+
+```bash
+gh extension install HikaruEgashira/gh-wt
+```
+
+Prerequisites:
+
+- GitHub CLI v2.90.0 or later
+- `fzf`, for the interactive worktree picker (already a Brewfile dependency; see [Tool list](./tools.md))
+- Linux kernel 5.11+ (OverlayFS) or macOS (APFS), for copy-on-write support
+
+## Usage
+
+```bash
+# Create a worktree for a branch
+gh wt add feature-branch
+
+# Remove a worktree, picking it interactively
+gh wt remove
+
+# Run a command inside a selected worktree (cd into it, then exec)
+gh wt -- claude
+gh wt -- npm test
+
+# Run a command with the worktree path passed as an argument (no cd)
+gh wt code
+gh wt cursor
+```
+
+The `--` separator controls how the target command receives the worktree: `gh wt -- <command>` changes into the worktree directory and then runs `<command>` there, while `gh wt <command>` (no `--`) runs `<command>` in the current directory with the worktree path appended as its last argument. Use the first form for shell-like commands and the second for editors or other tools that take a path argument.
+
+### Interactive worktree picker
+
+When a subcommand needs a worktree and none is given, `gh-wt` opens an `fzf` picker over the existing worktrees. The picker is skipped when:
+
+- There is only one candidate (`--select-1`)
+- `--at <branch|path>` pins the target explicitly
+- `GH_WT_NONINTERACTIVE=1` is set, in which case `gh-wt` exits with status `2` and prints the candidate list instead of prompting — useful in CI or agent-driven shells where `/dev/tty` is unavailable
+
+## Command list
+
+| Command                                 | Description                                                                                        |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `gh wt list`                            | List worktrees                                                                                     |
+| `gh wt add [--new\|-b] <branch> [path]` | Add a worktree (refuses to create a new branch unless `--new`/`-b` or `GH_WT_ASSUME_NEW=1` is set) |
+| `gh wt remove [target]`                 | Remove a worktree (refuses to remove the main worktree)                                            |
+| `gh wt gc`                              | Delete unreferenced cache entries                                                                  |
+| `gh wt [--at <wt>] <command>`           | Run `<command>` in or with a worktree                                                              |
+
+## Shell shortcut
+
+For interactive shells, this repository also provides a `gwt` zsh alias (the `go-to-worktree` function, defined in `dotfiles/zsh/go-to-worktree.zsh`). It runs `gh wt list` through the same `fzf` picker and `cd`s directly into the selected worktree, which is a lighter-weight alternative to `gh wt -- $SHELL` when you just want to move your current shell into a worktree. See [Zsh plugins](./zsh/plugins.md) for details.
+
+## Copilot skill
+
+`dotfiles/skills/gh-wt/` provides a Copilot CLI skill, installed from upstream with `gh skill install HikaruEgashira/gh-wt gh-wt`, that lets the agent create, list, and remove worktrees from natural-language requests. See [Copilot Skills](./skills.md) for details.
+
+## Gotchas
+
+> [!WARNING]
+> On macOS, the worktree's target path and `gh-wt`'s cache directory must be on the same APFS volume, or `clonefile(2)` fails with `apfs clone failed`. If you hit this, set `GH_WT_CACHE_DIR` to a path on the same volume as the target before running `gh wt add`.
+
+## References
+
+- [gh-wt repository](https://github.com/HikaruEgashira/gh-wt)
+- For the background behind this technology choice, see [ADR 0007](../development/99-adr/0007-gh-wt.md)

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -42,6 +42,7 @@ Installs the packages defined in `Brewfile` with `brew bundle`.
 Installs GitHub CLI extensions and adds related tools.
 
 - Install the `gh-q` (`HikaruEgashira/gh-q`) extension
+- Install the `gh-wt` (`HikaruEgashira/gh-wt`) extension (used for CoW-backed git worktrees; see [gh-wt](./gh-wt.md) for details)
 - Install the `gh-infra` (`babarot/gh-infra`) extension (used for declarative repository settings with `.github/settings.yml`; see [gh-infra](./gh-infra.md) for details)
 - Install `fd` (a fast file search tool) with Homebrew
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -4,10 +4,11 @@ This is the specification reference for custom skills.
 
 ## Skill list
 
-| Skill       | Description                                                                                                                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `pr-create` | Check the corresponding Task, understand the changes, and create a draft PR with an appropriate commit message and description |
-| `pr-fix`    | Fix CI errors and handle review comments to bring the PR into a mergeable state                                                |
+| Skill       | Description                                                                                                                                  |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gh-wt`     | Creates, lists, removes CoW-backed git worktrees via the gh-wt extension (installed from upstream via `gh skill install`, not hand-authored) |
+| `pr-create` | Check the corresponding Task, understand the changes, and create a draft PR with an appropriate commit message and description               |
+| `pr-fix`    | Fix CI errors and handle review comments to bring the PR into a mergeable state                                                              |
 
 ## Installation destination
 
@@ -17,11 +18,29 @@ When `install.sh` runs, `dotfiles/skills/` is symlinked to `~/.copilot/skills/`.
 
 ```
 dotfiles/skills/
+├── gh-wt/
+│   ├── SKILL.md
+│   └── evals/
+│       ├── evals.json
+│       └── trigger_queries.json
 ├── pr-create/
 │   └── SKILL.md
 └── pr-fix/
     └── SKILL.md
 ```
+
+## Skills installed via `gh skill install`
+
+Some skills, such as `gh-wt`, are not hand-authored in this repository. They are installed directly from an upstream repository with `gh skill install <repo> <skill>`, which fetches the skill's directory (including `SKILL.md` and any accompanying files) verbatim.
+
+- **Frontmatter**: may include extra fields outside this repo's own spec below, such as `compatibility`, `license`, and a `metadata` block (`github-path`, `github-ref`, `github-repo`, `github-tree-sha`) that record the provenance — source repo, tag, and commit — the content was synced from
+- **Language**: the `description` and body follow the upstream author's choice (English is fine) instead of this repo's Japanese convention for hand-authored skills
+- **Evals**: an installed skill may ship an `evals/` directory with author-provided test cases (`evals.json`, `trigger_queries.json`) that validate trigger phrases and expected behavior; these are tracked in git as-is, since they are static author-provided content rather than local generated or runtime state
+
+> [!IMPORTANT]
+> Do not hand-edit the `SKILL.md` of an installed skill to match this repo's format conventions below. Treat it as vendored/synced content — if it needs an update, re-run `gh skill install` to pull the latest upstream version instead.
+
+For `gh-wt`'s commands and usage, see [gh-wt](./gh-wt.md).
 
 ## `SKILL.md` format specification
 

--- a/docs/reference/zsh/plugins.md
+++ b/docs/reference/zsh/plugins.md
@@ -9,6 +9,7 @@ This is the detailed reference for the custom plugins placed in `dotfiles/zsh/`.
 | `gh-config-dir.zsh`               | —     | —          | Automatically configure Git identity and `GH_CONFIG_DIR` |
 | `go-to-ghq-repository.zsh`        | `ggr` | `C-]`      | Select a repository and `cd` into it                     |
 | `edit-ghq-repository.zsh`         | `egr` | —          | Select a repository and open it in `nvim`                |
+| `go-to-worktree.zsh`              | `gwt` | —          | Select a gh-wt worktree and `cd` into it                 |
 | `edit-selected-file.zsh`          | `esf` | —          | Select a file and open it in `nvim`                      |
 | `fzf-select-history.zsh`          | —     | `C-r`      | Search history with fzf                                  |
 | `browse-github-notifications.zsh` | `bgn` | —          | Browse GitHub notifications                              |
@@ -79,6 +80,26 @@ Runs `gh q nvim` via `run-selected-command`.
 ### Alias
 
 - `egr`
+
+---
+
+## go-to-worktree.zsh
+
+Get a list of [gh-wt](../gh-wt.md)-managed worktrees, select one with fzf, and `cd` into it.
+
+### Behavior
+
+1. Get a list of worktrees with `gh wt list`
+2. Select one with fzf, then extract its path with `awk`
+3. `cd` into the selected path
+
+### Keybinding
+
+Registered as a ZLE widget (`zle -N go-to-worktree`), but unlike `go-to-ghq-repository.zsh`'s `ggr` (bound to `C-]`), no key is bound by default. This is intentional, to avoid colliding with existing bindings. Bind one yourself if desired, e.g. `bindkey '^w' go-to-worktree`.
+
+### Alias
+
+- `gwt`
 
 ---
 

--- a/dotfiles/skills/gh-wt/SKILL.md
+++ b/dotfiles/skills/gh-wt/SKILL.md
@@ -1,0 +1,63 @@
+---
+compatibility: Requires `gh`, `fzf`, and macOS on APFS or Linux 5.11+ with OverlayFS. Install once with `gh extension install HikaruEgashira/gh-wt`.
+description: Use this skill whenever the user wants to operate on git worktrees — create, enter, list, remove, or garbage-collect — including parallel agent sessions, side-by-side PR reviews, benchmarking multiple branches, or isolating a dirty tree from a fresh checkout. Trigger even when "worktree" is not said — phrasings like "spin up a fresh copy of branch X", "run claude in a clean checkout", "try this patch without touching my changes", or "open PR-123 side-by-side with main" all qualify. Do NOT trigger for conceptual or educational questions about git worktree (e.g. "what's the difference between git worktree and git clone?") — those are answered from general git knowledge, not this skill.
+license: MIT
+metadata:
+    github-path: skills/gh-wt
+    github-ref: refs/tags/v0.2.1
+    github-repo: https://github.com/HikaruEgashira/gh-wt
+    github-tree-sha: 5ea56fcd86b2486cfd211dbf6b04f01f1b34f116
+name: gh-wt
+---
+# gh-wt
+
+`gh wt` creates CoW-backed git worktrees. Prefer it over `git worktree add`
+when the user wants multiple concurrent worktrees.
+
+If `gh wt` is unavailable, run `gh extension install HikaruEgashira/gh-wt`
+and retry.
+
+## Commands
+
+```
+gh wt add <branch> [path]   Create a worktree (creates or tracks <branch>)
+gh wt list                  List worktrees
+gh wt remove [target]       Remove a worktree; target = path or branch name
+gh wt gc                    Delete unreferenced cache entries
+gh wt -- <cmd> [args...]    cd into selected worktree, then exec <cmd>
+gh wt <cmd> [args...]       Run <cmd> with selected worktree path appended
+```
+
+When a subcommand needs a worktree and none is given, `fzf` opens for
+selection. `Esc` cancels cleanly (exit 0).
+
+## `--` vs no `--`
+
+- **`gh wt -- <cmd>`** — cwd becomes the worktree, then `<cmd>` runs.
+  Use for shells, agents, and test runners: `gh wt -- claude`,
+  `gh wt -- bash`, `gh wt -- npm test`.
+- **`gh wt <cmd>`** — worktree path is appended as an argument.
+  Use for editors and openers that take a path: `gh wt code`,
+  `gh wt cursor`.
+
+Mnemonic: `--` means "into"; no `--` means "with path".
+
+## Typical requests → commands
+
+| User says                               | Command                       |
+| --------------------------------------- | ----------------------------- |
+| "new worktree for `<branch>`"           | `gh wt add <branch>`          |
+| "run claude / my agent in a worktree"   | `gh wt -- claude`             |
+| "open `<worktree>` in VS Code / Cursor" | `gh wt code` / `gh wt cursor` |
+| "run tests in a separate worktree"      | `gh wt -- npm test`           |
+| "remove the `<branch>` worktree"        | `gh wt remove <branch>`       |
+| "show me all worktrees"                 | `gh wt list`                  |
+| "clean up unused worktree cache"        | `gh wt gc`                    |
+
+## Gotchas
+
+- **macOS cross-volume**: the target path and the cache dir must be on
+  the same APFS volume, or `clonefile(2)` fails with `apfs clone failed`.
+  Fix by setting `GH_WT_CACHE_DIR=/path/on/same/volume` before
+  `gh wt add`.
+- `gh wt remove` refuses the main worktree.

--- a/dotfiles/skills/gh-wt/evals/evals.json
+++ b/dotfiles/skills/gh-wt/evals/evals.json
@@ -1,0 +1,66 @@
+{
+  "skill_name": "gh-wt",
+  "evals": [
+    {
+      "id": "add-basic",
+      "prompt": "I want to spin up a fresh worktree for the branch experiment-a so I can try some stuff without touching my current tree.",
+      "expected_output": "Runs `gh wt add experiment-a` and reports the resulting worktree path.",
+      "assertions": [
+        "The command executed is exactly `gh wt add experiment-a` (no extra flags, no `--`)",
+        "If `gh wt --help` was not verified first and the command fails, the agent runs `gh extension install HikaruEgashira/gh-wt` before retrying",
+        "The final response mentions the worktree path or branch name",
+        "The agent does not fall back to plain `git worktree add`"
+      ]
+    },
+    {
+      "id": "exec-in-agent",
+      "prompt": "Start claude code inside one of my existing worktrees.",
+      "expected_output": "Runs `gh wt -- claude` (interactive fzf-based selection), so claude starts with the worktree as cwd.",
+      "assertions": [
+        "The command executed is `gh wt -- claude` (with the `--` separator)",
+        "The agent does NOT run `gh wt claude` without `--`",
+        "The agent notes that fzf will prompt for selection"
+      ]
+    },
+    {
+      "id": "open-in-editor",
+      "prompt": "Open my experiment-b worktree in VS Code.",
+      "expected_output": "Runs `gh wt code`, which appends the selected worktree path as an argument to `code`.",
+      "assertions": [
+        "The command executed is `gh wt code` (no `--` separator)",
+        "The agent does NOT run `gh wt -- code` (which would cd into the worktree and exec `code .`-less)",
+        "The agent notes that the worktree path is appended to `code`"
+      ]
+    },
+    {
+      "id": "remove-by-branch",
+      "prompt": "Get rid of the feature-auth worktree, I'm done with it.",
+      "expected_output": "Runs `gh wt remove feature-auth` (passes the branch name as target).",
+      "assertions": [
+        "The command executed is `gh wt remove feature-auth`",
+        "The agent does not prompt for interactive fzf selection when a branch name was given",
+        "The agent does not delete the main worktree"
+      ]
+    },
+    {
+      "id": "gc",
+      "prompt": "Free up any disk used by worktree caches I'm not using anymore.",
+      "expected_output": "Runs `gh wt gc` and reports how many reference trees were removed.",
+      "assertions": [
+        "The command executed is exactly `gh wt gc`",
+        "The agent does not run `git gc` (unrelated)",
+        "The agent does not manually rm anything in `~/.cache/gh-wt`"
+      ]
+    },
+    {
+      "id": "clonefile-failure-recovery",
+      "prompt": "I got `apfs clone failed` when running `gh wt add feature-x /Volumes/ExternalSSD/feature-x`. What do I do?",
+      "expected_output": "Diagnoses the cross-volume issue and suggests setting `GH_WT_CACHE_DIR` to a path on the same APFS volume as the target.",
+      "assertions": [
+        "The diagnosis mentions that the target path must be on the same APFS volume as the cache",
+        "The suggested fix sets `GH_WT_CACHE_DIR` to a directory on `/Volumes/ExternalSSD`",
+        "The agent does not suggest switching away from `gh wt` or falling back to `git worktree add` as the primary fix"
+      ]
+    }
+  ]
+}

--- a/dotfiles/skills/gh-wt/evals/trigger_queries.json
+++ b/dotfiles/skills/gh-wt/evals/trigger_queries.json
@@ -1,0 +1,23 @@
+[
+  { "query": "I need to run three claude agents on three different feature branches without re-cloning the repo each time.", "should_trigger": true },
+  { "query": "spin up a fresh checkout of pr-123 alongside my current main so I can build it without switching.", "should_trigger": true },
+  { "query": "open the feature-auth branch in a separate working directory, I don't want to stash my changes.", "should_trigger": true },
+  { "query": "I want to benchmark 5 commits of this repo at once. what's the cheapest way to get 5 checkouts?", "should_trigger": true },
+  { "query": "remove that stale worktree I made yesterday for the hotfix branch.", "should_trigger": true },
+  { "query": "run npm test in a separate checkout without touching what I'm working on right now.", "should_trigger": true },
+  { "query": "clean up any cached reference trees on disk that nothing is using anymore.", "should_trigger": true },
+  { "query": "show me all the linked working trees for this repo.", "should_trigger": true },
+  { "query": "I want to try this patch in an isolated copy of the repo; keep my dirty tree alone.", "should_trigger": true },
+  { "query": "give me another checkout of main so I can run the build there while I edit here.", "should_trigger": true },
+
+  { "query": "create a new branch called feature-auth off main.", "should_trigger": false },
+  { "query": "I need to clone a fresh copy of the HikaruEgashira/gh-wt repo from GitHub.", "should_trigger": false },
+  { "query": "list all branches in this repo, including remote ones.", "should_trigger": false },
+  { "query": "what's the conceptual difference between `git worktree` and `git clone`?", "should_trigger": false },
+  { "query": "delete the feature-auth branch — both local and remote.", "should_trigger": false },
+  { "query": "how much disk space is my .git directory using?", "should_trigger": false },
+  { "query": "switch my current checkout to the feature-auth branch.", "should_trigger": false },
+  { "query": "run `git gc --aggressive` to clean up unreachable objects.", "should_trigger": false },
+  { "query": "open main.py in VS Code.", "should_trigger": false },
+  { "query": "install the github cli on this mac.", "should_trigger": false }
+]

--- a/dotfiles/zsh/go-to-worktree.zsh
+++ b/dotfiles/zsh/go-to-worktree.zsh
@@ -1,0 +1,18 @@
+function go-to-worktree() {
+  local query="${1:-${LBUFFER:-}}"
+  local selected_path
+
+  selected_path="$(gh wt list | fzf --query "$query" --select-1 --reverse --height=20 | awk '{print $1}')"
+  if [[ -n "$selected_path" ]]; then
+    cd "$selected_path"
+
+    if [[ -n "${WIDGET:-}" ]]; then
+      zle reset-prompt
+    fi
+  fi
+}
+
+alias gwt='go-to-worktree'
+zle -N go-to-worktree
+# No default keybinding to avoid colliding with existing bindings (^]=ggr, ^r=history search).
+# Bind one yourself if desired, e.g.: bindkey '^w' go-to-worktree

--- a/scripts/100-gh-extensions.sh
+++ b/scripts/100-gh-extensions.sh
@@ -13,6 +13,7 @@ fi
 
 extensions=(
   "HikaruEgashira/gh-q"
+  "HikaruEgashira/gh-wt"
   "babarot/gh-infra"
 )
 


### PR DESCRIPTION
## Purpose

Introduce [`gh-wt`](https://github.com/HikaruEgashira/gh-wt) (`HikaruEgashira/gh-wt`), a GitHub CLI extension for fast, disk-efficient git worktrees, and make it available through three surfaces: the `gh` extension itself, a Copilot CLI skill, and an interactive shell shortcut.

## Background

Plain `git worktree add` copies every tracked file into each new worktree, so disk usage grows linearly and creation gets slower as more worktrees are used — a real cost for workflows this repo already leans on, like parallel agent sessions and side-by-side PR review. `gh-wt` avoids this by backing worktrees with copy-on-write (OverlayFS on Linux, APFS `clonefile(2)` on macOS); upstream benchmarks show ~8x less disk at 10 concurrent worktrees and ~13x less at 20.

> [!NOTE]
> The `gh-wt` extension install and the Copilot skill files already existed uncommitted/untracked in the working tree before this PR. This change tracks them, adds the shell shortcut, and documents all of it.

## What changed

| Area | Change |
| --- | --- |
| Extension | `scripts/100-gh-extensions.sh` now installs `HikaruEgashira/gh-wt` alongside `gh-q` and `gh-infra` |
| Copilot skill | `dotfiles/skills/gh-wt/` (installed from upstream via `gh skill install`), so the agent can create/list/remove worktrees from natural-language requests |
| Shell shortcut | `gwt` (`dotfiles/zsh/go-to-worktree.zsh`) fzf-selects a `gh wt` worktree and `cd`s into it, mirroring the existing `ggr` pattern |
| ADR | [`0007-gh-wt.md`](docs/development/99-adr/0007-gh-wt.md) records the decision and alternatives considered (plain `git worktree add`, `gh-q`) |
| Reference | New [`docs/reference/gh-wt.md`](docs/reference/gh-wt.md) covers setup, commands, the `--`/no-`--` forwarding distinction, the fzf picker, and the macOS same-APFS-volume gotcha |
| Docs wiring | Updated the ADR index, reference index, `scripts.md`, `skills.md`, `guides/06-skills.md`, `zsh/plugins.md`, and the `copilot-instructions.md` doc mapping table |

> [!IMPORTANT]
> `dotfiles/skills/gh-wt/` is vendored from upstream (not hand-authored), so its `SKILL.md` frontmatter and `evals/` directory differ from this repo's own skill conventions — this is called out explicitly in `docs/reference/skills.md` so it isn't mistaken for an inconsistency later.

## Verification

- [x] `zsh -n dotfiles/zsh/go-to-worktree.zsh` — no syntax errors
- [x] `bun run docs:build` — production Docusaurus build succeeds with zero broken links
- [x] Manually confirmed `gh wt list` output format (`<path> <sha> [branch]`) matches what `go-to-worktree.zsh` expects
