### PR TITLE
docs(skills): add pr-merge skill and merge workflow docs

### DIFF
--- a/docs/development/03-skills-development.md
+++ b/docs/development/03-skills-development.md
@@ -15,7 +15,7 @@ touch dotfiles/skills/<skill-name>/SKILL.md
 
 ```markdown
 ---
-description: Skill description (one line, in Japanese)
+description: Skill description (one line, in English)
 name: skill-name
 ---
 
@@ -58,7 +58,7 @@ If you see a loading error, check whether the `name` and `description` in the fr
 
 | Rule                      | Reason                                                      |
 | ------------------------- | ----------------------------------------------------------- |
-| Write in Japanese         | To keep both the body text and `description` in Japanese    |
+| Write in English          | To keep both the body text and `description` in English     |
 | Write concrete steps      | Ambiguity makes the agent hesitate when deciding what to do |
 | State constraints clearly | Prevents infinite loops and destructive operations          |
 | Define the output         | Clarifies what the user can expect                          |

--- a/docs/guides/06-skills.md
+++ b/docs/guides/06-skills.md
@@ -13,6 +13,7 @@ This is a guide for getting started quickly with custom Copilot CLI skills.
 | ----------- | ----------------------------------------------------------------------------------------- |
 | `pr-create` | Automatically creates a draft PR from the current changes                                 |
 | `pr-fix`    | Fixes CI errors, handles reviews, and resolves merge conflicts for the specified PR       |
+| `pr-merge`  | Loops `pr-fix` and Copilot Code Review to zero findings, then approves, waits for CI, and squash merges one or more PRs |
 | `gh-wt`     | Creates and manages CoW-backed git worktrees (list/add/remove/gc) via the gh-wt extension |
 
 ## Use `pr-create`
@@ -63,6 +64,35 @@ copilot -p "/pr-fix feedback #42"  # Review comments only
 copilot -p "/pr-fix conflicts #42" # Conflicts only
 ```
 
+## Use `pr-merge`
+
+```bash
+copilot -p "/pr-merge 42"
+```
+
+Multiple PRs can be given at once, separated by spaces; they are processed one at a time:
+
+```bash
+copilot -p "/pr-merge 42 43"
+```
+
+In an interactive session, you can also start it with `/pr merge` (described later).
+
+### What happens
+
+For each PR number given:
+
+1. Runs `pr-fix` and requests a review from Copilot Code Review, repeating until there are no unresolved findings (up to 10 attempts)
+2. Takes the PR out of Draft and applies the `self approval` label
+3. Waits for the repository's existing self-approval automation to approve the PR (up to 3 minutes)
+4. Waits for CI to go green, going back to step 1 if a merge conflict or a CI failure shows up
+5. Squash merges the PR once everything is green
+
+If a PR cannot be brought to a mergeable state, it is skipped (with the reason recorded) so the rest of the batch keeps going, and a summary is reported at the end.
+
+> [!IMPORTANT]
+> `pr-merge` waits for an existing automation that approves PRs labeled `self approval` — it does not create that automation. It also expects the `self approval` label to already exist in the repository.
+
 ## Use `gh-wt`
 
 Unlike `pr-create` and `pr-fix`, `gh-wt` is not a hand-authored skill and has no slash command. It was
@@ -103,18 +133,19 @@ See the [gh-wt reference](../reference/gh-wt.md) for the full command list (`gh 
 > Prefer a plain shell shortcut over an AI round-trip? The `gwt` function fzf-selects a worktree and `cd`s
 > into it directly, without going through Copilot. See [zsh plugins](../reference/zsh/plugins.md) for details.
 
-## Integration with `/pr create` and `/pr fix`
+## Integration with `/pr create`, `/pr fix`, and `/pr merge`
 
 `install.sh` creates a symbolic link from `dotfiles/copilot-instructions.md` to `~/.copilot/copilot-instructions.md`.
 This file contains the following instructions and is always loaded in interactive sessions:
 
 - When `/pr create` is invoked → use the `pr-create` skill
 - When `/pr fix` is invoked → use the `pr-fix` skill
+- When `/pr merge` is invoked → use the `pr-merge` skill
 
 As a result, even when you use the built-in `/pr` subcommand, it behaves according to the procedure defined in the skills.
 
 > [!NOTE]
-> This integration works through Copilot instruction loading and is not a completely deterministic binding. If you want to ensure the skill is used, invoke it directly with `/pr-create` or `/pr-fix`.
+> This integration works through Copilot instruction loading and is not a completely deterministic binding. If you want to ensure the skill is used, invoke it directly with `/pr-create`, `/pr-fix`, or `/pr-merge`.
 
 ## Alias setup (recommended)
 
@@ -123,6 +154,7 @@ Add the following to `.zshrc` or `.bashrc`:
 ```bash
 alias pr-create='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-create skill $*"; }; f'
 alias pr-fix='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-fix skill $*"; }; f'
+alias pr-merge='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-merge skill $*"; }; f'
 ```
 
 Usage:
@@ -130,4 +162,5 @@ Usage:
 ```bash
 pr-create
 pr-fix PR #42
+pr-merge 42
 ```

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -9,6 +9,7 @@ This is the specification reference for custom skills.
 | `gh-wt`     | Creates, lists, removes CoW-backed git worktrees via the gh-wt extension (installed from upstream via `gh skill install`, not hand-authored) |
 | `pr-create` | Check the corresponding Task, understand the changes, and create a draft PR with an appropriate commit message and description               |
 | `pr-fix`    | Fix CI errors and handle review comments to bring the PR into a mergeable state                                                              |
+| `pr-merge`  | Loop `pr-fix` and Copilot Code Review until there are no findings, then take the PR ready, label it, wait for approval and CI, and squash merge |
 
 ## Installation destination
 
@@ -25,7 +26,9 @@ dotfiles/skills/
 │       └── trigger_queries.json
 ├── pr-create/
 │   └── SKILL.md
-└── pr-fix/
+├── pr-fix/
+│   └── SKILL.md
+└── pr-merge/
     └── SKILL.md
 ```
 
@@ -34,7 +37,7 @@ dotfiles/skills/
 Some skills, such as `gh-wt`, are not hand-authored in this repository. They are installed directly from an upstream repository with `gh skill install <repo> <skill>`, which fetches the skill's directory (including `SKILL.md` and any accompanying files) verbatim.
 
 - **Frontmatter**: may include extra fields outside this repo's own spec below, such as `compatibility`, `license`, and a `metadata` block (`github-path`, `github-ref`, `github-repo`, `github-tree-sha`) that record the provenance — source repo, tag, and commit — the content was synced from
-- **Language**: the `description` and body follow the upstream author's choice (English is fine) instead of this repo's Japanese convention for hand-authored skills
+- **Language**: the `description` and body follow the upstream author's choice (English is fine) — the same as this repo's own English convention for hand-authored skills, though vendored skills are not required to follow this repo's structure to begin with
 - **Evals**: an installed skill may ship an `evals/` directory with author-provided test cases (`evals.json`, `trigger_queries.json`) that validate trigger phrases and expected behavior; these are tracked in git as-is, since they are static author-provided content rather than local generated or runtime state
 
 > [!IMPORTANT]
@@ -52,7 +55,7 @@ Frontmatter is required. The section structure of the body can be freely defined
 
 ```markdown
 ---
-description: Skill description (1 line, in Japanese)
+description: Skill description (1 line, in English)
 name: Skill name
 ---
 
@@ -81,7 +84,7 @@ name: Skill name
 
 ```markdown
 ---
-description: Skill description (1 line, in Japanese)
+description: Skill description (1 line, in English)
 name: Skill name
 ---
 
@@ -115,8 +118,8 @@ name: Skill name
 
 ### Language used in the body
 
-- Write the frontmatter `description` in **Japanese** (used in the CLI skill list display)
-- Write the body in **Japanese**
+- Write the frontmatter `description` in **English** (used in the CLI skill list display)
+- Write the body in **English**
 
 ### Section guidelines
 
@@ -168,3 +171,31 @@ name: Skill name
 
 - Replies to each review comment
 - Error report if CI still does not pass
+
+## Detailed specification for `pr-merge`
+
+### Workflow
+
+`pr-merge` runs a single retry loop (up to 10 iterations) per PR:
+
+1. Run `/pr-fix all <PR>`, request a review from Copilot Code Review (same GraphQL mutation as `pr-fix`), and wait for it to complete
+2. Count the unresolved findings left by Copilot Code Review (paginated `reviewThreads`, filtered to `copilot-pull-request-reviewer`); if any remain, go back to step 1
+3. Mark the PR ready for review (`gh pr ready`) and apply the `self approval` label
+4. Wait for the pre-existing self-approval automation to approve the PR (short 3-minute timeout, since a miss usually means the automation is not configured)
+5. Wait for CI to go green and re-check mergeability; a merge conflict or a CI failure sends control back to step 1, since `/pr-fix all` can fix both
+6. Once CI is green and there are no conflicts, squash merge (`gh pr merge --squash --delete-branch`)
+
+Multiple PR numbers are processed one at a time; a PR that fails or times out is skipped (recorded) so the rest of the batch still runs.
+
+> [!NOTE]
+> `pr-merge` assumes an automation that approves PRs labeled `self approval` already exists (outside this skill's scope) and only waits for its result. It also assumes the `self approval` label already exists in the repository; it does not create the label.
+
+### Input
+
+- One or more PR numbers (required)
+
+### Output
+
+- The merged PR's URL for each successfully merged PR
+- The failure reason (which step, and why) for any PR that could not be merged
+- A final summary across all given PR numbers

--- a/dotfiles/copilot-instructions.md
+++ b/dotfiles/copilot-instructions.md
@@ -4,6 +4,7 @@
 
 If the user runs `/pr create` or asks to create a Pull Request, always use the `pr-create` skill.
 If the user runs `/pr fix` or asks to fix, improve, or make a Pull Request mergeable, always use the `pr-fix` skill.
+If the user runs `/pr merge` or asks to merge a Pull Request once review is clean, always use the `pr-merge` skill.
 
 ## Comments on Issues / Pull Requests
 

--- a/dotfiles/skills/pr-merge/SKILL.md
+++ b/dotfiles/skills/pr-merge/SKILL.md
@@ -1,0 +1,132 @@
+---
+description: A skill used to take a Pull Request all the way to merged. It resolves Copilot Code Review feedback in a loop, marks the PR ready for review, applies the `self approval` label, waits for approval and CI, and performs a squash merge. This also applies when `/pr merge` is invoked.
+name: pr-merge
+---
+
+# pr-merge
+
+## Overview
+
+This is a skill for taking one or more Pull Requests from "ready for final review" all the way to "merged". For each PR, it repeatedly runs the `pr-fix` skill and requests a review from Copilot Code Review until there are no unresolved findings, then takes the PR out of Draft, applies the `self approval` label, waits for the pre-existing approval automation and for CI to go green, and finally performs a squash merge.
+
+## When to use
+
+- When `/pr-merge` is invoked
+- When asked to merge a PR (or several PRs) once review is clean, for example "merge PR #42 once it's ready" or "run these PRs through to merge"
+
+## Usage
+
+```
+/pr-merge <PR number> [<PR number> ...]
+```
+
+- One or more PR numbers, separated by spaces
+- Example: `/pr-merge 12 34`
+- PRs are processed one at a time, in the order given
+
+## Procedure (per PR)
+
+Treat steps 1 through 5 below as a single retry loop, capped at **10 iterations**. Two conditions send control back to the top of the loop; everything else either continues normally or stops and reports (see "Retryable vs. non-retryable failures").
+
+### Step 1: Resolve Copilot Code Review feedback
+
+1. Run `/pr-fix all <PR number>` (fixes merge conflicts, CI failures, and review feedback together)
+2. Request a review from Copilot Code Review, using the same GraphQL mutation as `pr-fix`:
+   - Get the PR node ID: `gh pr view <PR_NUMBER> --json id -q .id`
+   - Request the review:
+     ```
+     gh api graphql -f query='
+     mutation {
+       requestReviews(input: {
+         pullRequestId: "<PR_NODE_ID>",
+         botIds: ["BOT_kgDOCnlnWA"],
+         union: true
+       }) {
+         pullRequest {
+           reviewRequests(first: 5) {
+             nodes {
+               requestedReviewer {
+                 __typename
+                 ... on Bot { login }
+               }
+             }
+           }
+         }
+       }
+     }'
+     ```
+   - `BOT_kgDOCnlnWA` is the GraphQL node ID for `copilot-pull-request-reviewer`
+3. Wait for the review to complete: poll once per minute, up to 30 minutes, for a review from `copilot-pull-request-reviewer` whose `submittedAt` is after the request was sent (check with `gh pr view <PR_NUMBER> --json latestReviews`)
+   - If 30 minutes pass with no review appearing, stop processing this PR and report the timeout (not retryable)
+4. Count the unresolved findings left by Copilot Code Review:
+   - Paginate `reviewThreads(first: 100, after: $cursor)` (same pattern as `pr-fix`'s feedback mode), following `pageInfo { hasNextPage endCursor }` until `hasNextPage` is `false`
+   - For each thread, check `isResolved` and the login of the thread's first comment author
+   - Count the threads where `isResolved` is `false` and the comment author is `copilot-pull-request-reviewer`
+5. If that count is greater than 0, go back to the top of the loop (Step 1)
+
+### Step 2: Mark the PR ready for review
+
+- `gh pr ready <PR number>`
+- Idempotent — safe to run again if the loop repeats
+
+### Step 3: Apply the `self approval` label
+
+- `gh pr edit <PR number> --add-label "self approval"`
+- The label is expected to already exist in the repository. If `gh` reports that the label does not exist, stop processing this PR immediately and report the error. Do not create the label, and do not retry — this is not something another loop iteration can fix.
+
+### Step 4: Wait for bot approval
+
+- Immediately after applying the label, record the current time
+- Poll once per minute, up to **3 minutes** (3 checks), for a review with `state: APPROVED` whose `submittedAt` is after the recorded time (check with `gh pr view <PR number> --json reviews` or `latestReviews`)
+  - This repository already has a separate, pre-existing automation that approves PRs labeled `self approval`; this skill only waits for its result and does not build or configure that automation
+- If no approval appears within 3 minutes, stop processing this PR immediately and report that the self-approval automation is likely not configured or not running. Do not retry — this short timeout is intentional, to surface that case quickly rather than waiting the full 30 minutes used elsewhere.
+
+### Step 5: Wait for CI to go green (and re-check mergeability)
+
+- Poll once per minute, up to 30 minutes, checking both:
+  - `gh pr checks <PR number> --required` for CI status
+  - `gh pr view <PR number> --json mergeable,mergeStateStatus` for merge-conflict status
+- If `mergeable` is `CONFLICTING`, go back to the top of the loop (Step 1) — `/pr-fix all` resolves conflicts as its first phase
+- If any required check's bucket is `fail`, go back to the top of the loop (Step 1) — `/pr-fix all` will attempt to fix the CI failure
+- If 30 minutes pass without reaching a fully green state and without either condition above appearing (for example, checks stuck in `pending`), stop processing this PR immediately and report the timeout (not retryable)
+- If every required check is `pass` (or `skipping`) and `mergeable` shows no conflicts, exit the loop and proceed to Step 6
+
+### Step 6: Squash merge
+
+- `gh pr merge <PR number> --squash --delete-branch`
+
+## Retryable vs. non-retryable failures
+
+| Condition | Behavior |
+| --- | --- |
+| Unresolved Copilot Code Review findings (Step 1) | Retryable — back to Step 1 |
+| Merge conflict detected (Step 5) | Retryable — back to Step 1 |
+| CI failure detected (Step 5) | Retryable — back to Step 1 |
+| Missing `self approval` label (Step 3) | Not retryable — stop and report |
+| Bot-approval timeout, 3 minutes (Step 4) | Not retryable — stop and report |
+| Review-completion timeout, 30 minutes (Step 1) | Not retryable — stop and report |
+| CI/mergeability-wait timeout, 30 minutes (Step 5) | Not retryable — stop and report |
+| Loop exceeds 10 iterations | Not retryable — stop and report |
+
+Because `gh pr ready` and `gh pr edit --add-label` are idempotent, and this repository's branch protection has `dismiss_stale_reviews_on_push: false`, an approval obtained on an earlier iteration is not dismissed by later commits (from a conflict or CI fix made on a later iteration). Re-running Steps 2–4 on a later iteration is therefore safe, and Step 4 in particular typically resolves immediately without any real waiting, since the earlier approval is still valid.
+
+## Processing multiple PRs
+
+- Run the full per-PR procedure above for each PR number given, in order
+- If a PR fails or times out (per the table above), record the reason, skip it, and continue with the next PR number — do not stop the whole batch
+- After all PR numbers have been processed, report a summary listing, for each PR, either the merged PR's URL or the reason it was not merged
+
+## Constraints
+
+- Polling interval for every waiting step is 1 minute
+- Timeouts: 30 minutes for the review-completion wait (Step 1) and the CI/mergeability wait (Step 5); 3 minutes for the bot-approval wait (Step 4)
+- Maximum 10 iterations of the retry loop per PR
+- Never auto-create the `self approval` label — treat a missing label as a hard error for that PR
+- Building or configuring the approval automation itself is out of scope for this skill; it only waits for the existing mechanism
+- Do not force-push unless explicitly instructed (same constraint as `pr-fix`)
+- Only use squash merges, matching this repository's merge strategy settings (`allow_squash_merge` only)
+
+## Output
+
+- For each PR: the merged PR's URL on success, or the failure reason (which step, and why) if it could not be merged
+- A final summary listing successes and failures across all PR numbers given


### PR DESCRIPTION
## Purpose

- add a new `pr-merge` skill that runs the existing merge workflow end to end for one or more PRs
- loop through `/pr-fix all`, Copilot Code Review feedback, draft-state handling, self-approval, CI, and squash merge until the PR is ready to merge
- document the workflow and wire `/pr merge` to the new skill

## Background

The repository already had `pr-create` and `pr-fix` skills, but no final merge automation step. This change fills that gap by adding a dedicated `pr-merge` skill and documenting how it fits into the existing Copilot skill workflow.
