### PR TITLE
docs(tmux): add automatic equal-sized pane layouts on split

### DIFF
--- a/docs/reference/tmux.md
+++ b/docs/reference/tmux.md
@@ -18,13 +18,17 @@ This is the configuration reference for the terminal multiplexer (tmux).
 
 ### Window and pane operations
 
-| Key              | Action                                       |
-| ---------------- | -------------------------------------------- |
-| `prefix c`       | New window (inherits the current path)       |
-| `prefix \`       | Horizontal split (inherits the current path) |
-| `prefix -`       | Vertical split (inherits the current path)   |
-| `prefix h/j/k/l` | Move between panes (vim-style)               |
-| `prefix r`       | Reload configuration                         |
+| Key              | Action                                                          |
+| ---------------- | --------------------------------------------------------------- |
+| `prefix c`       | New window (inherits the current path)                          |
+| `prefix \`       | Horizontal split with even-sized layout (inherits current path) |
+| `prefix -`       | Vertical split with even-sized layout (inherits current path)   |
+| `prefix h/j/k/l` | Move between panes (vim-style)                                  |
+| `prefix r`       | Reload configuration                                            |
+
+When splitting panes, they automatically arrange in equal sizes using tmux's
+native layout engine. Each subsequent split redistributes space evenly among all
+panes. This works seamlessly whether you split into 2, 3, or more panes.
 
 ### Copy mode
 

--- a/dotfiles/tmux.conf
+++ b/dotfiles/tmux.conf
@@ -13,8 +13,8 @@ bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
 # New window / split panes (keep current path)
 bind c new-window -c "#{pane_current_path}"
-bind \\ split-window -h -c "#{pane_current_path}"
-bind - split-window -v -c "#{pane_current_path}"
+bind \\ split-window -h -c "#{pane_current_path}" \; select-layout even-horizontal
+bind - split-window -v -c "#{pane_current_path}" \; select-layout even-vertical
 unbind '"'
 unbind %
 


### PR DESCRIPTION
## 🎯 Purpose

This PR enhances the tmux pane splitting behavior to automatically arrange panes with equal sizes whenever they are split. This improves the user experience by eliminating the need to manually resize panes after splitting, especially when creating multiple panes in quick succession.

## 📋 Changes

### Configuration (dotfiles/tmux.conf)
- Modified `prefix \` binding to apply `select-layout even-horizontal` after splitting
- Modified `prefix -` binding to apply `select-layout even-vertical` after splitting
- Both bindings preserve the existing behavior of inheriting the current pane's working directory

### Documentation (docs/reference/tmux.md)
- Updated the keybindings table to clarify that splits now include automatic layout
- Added explanatory note about how the native tmux layout engine works
- Documented that this works seamlessly for 2, 3, or more panes

## ✨ Behavior

**Before:** Splitting panes would create new panes with potentially unequal sizes

**After:** All panes automatically arrange with equal distribution

## 🔍 Technical Details

- Uses tmux's built-in `select-layout` command with `even-horizontal` and `even-vertical` presets
- No new dependencies or plugins required
- Leverages tmux's native layout engine for optimal performance

## ✅ Testing

Configuration syntax validated with `tmux source-file`
- No errors loading the configuration
- Ready for real-world testing in tmux session
