### PR TITLE
feat(zsh): add ghq shortcut for gh qwt

### DIFF
--- a/docs/reference/gh-qwt.md
+++ b/docs/reference/gh-qwt.md
@@ -76,10 +76,12 @@ gh qwt path cli/cli/fix/parser
 
 ## Shell shortcuts
 
-For interactive shells, this repository provides two zsh functions built on `gh qwt list` and `gh qwt root`:
+For interactive shells, this repository provides zsh functions built on `gh qwt list` and `gh qwt root`:
 
 - `ggr` (`go-to-qwt-repository`, bound to `C-]`) — fzf-selects a repository or worktree and `cd`s into it
 - `egr` (`edit-qwt-repository`) — fzf-selects a repository or worktree and opens it in `nvim`
+
+It also provides a `ghq` shortcut that invokes `gh qwt` and uses `gh`'s own zsh completion. See `dotfiles/zsh/ghq.zsh` for the implementation.
 
 See [Zsh plugins](./zsh/plugins.md) for details.
 

--- a/dotfiles/zsh/ghq.zsh
+++ b/dotfiles/zsh/ghq.zsh
@@ -1,0 +1,11 @@
+# Shortcut for `gh qwt` that reuses gh's zsh completion.
+function ghq() {
+  gh qwt "$@"
+}
+
+function _ghq() {
+  words=(gh qwt ${words[2,-1]})
+  (( CURRENT += 2 ))
+  _gh
+}
+compdef _ghq ghq


### PR DESCRIPTION
## Purpose

Add a `ghq` zsh shortcut that invokes `gh qwt`, so users can type `ghq <subcommand>` instead of `gh qwt <subcommand>`.

## Background

`gh-qwt` was adopted in #26 to unify repository cloning and per-branch worktree management. The extension is invoked as `gh qwt <COMMAND>`. Typing the two-word prefix repeatedly is slightly verbose for interactive use, so this PR adds a shorter `ghq` alias-like function.

## Changes

| File | Change |
| --- | --- |
| `dotfiles/zsh/ghq.zsh` (new) | Add `ghq()` function that forwards to `gh qwt "$@"` |
| `dotfiles/zsh/ghq.zsh` (new) | Add `_ghq()` completion function that rewrites completion words to `gh qwt ...` and delegates to gh's built-in `_gh` completion |
| `docs/reference/gh-qwt.md` | Mention the `ghq` shortcut in the Shell shortcuts section |

## Notes

> [!NOTE]
> This intentionally reuses the name `ghq`, which previously referred to the standalone `x-motemen/ghq` binary removed in ADR 0004. Since `ghq` is no longer installed via the Brewfile, reclaiming the name is safe.

> [!TIP]
> A simple `alias ghq='gh qwt'` would not support zsh completion for `gh qwt` subcommands, so a function wrapper with a custom completion function is used.
