### PR TITLE
fix(zsh): share gh authentication across worktrees

### DIFF
--- a/docs/development/99-adr/0009-shared-worktree-gh-auth.md
+++ b/docs/development/99-adr/0009-shared-worktree-gh-auth.md
@@ -1,0 +1,75 @@
+# ADR 0009: Share gh authentication across Git worktrees
+
+Use one GitHub CLI authentication directory for every worktree of a repository, including repository-level `.gh/` storage for gh-qwt.
+
+## Status
+
+Accepted
+
+## Context
+
+`gh-config-dir.zsh` previously used `git rev-parse --git-path gh`. Git resolves
+that path inside each linked worktree's administrative directory, so every
+worktree required a separate `gh auth login`.
+
+This conflicts with the gh-qwt layout: a qwt repository has one shared bare Git
+database at `<qwt_root>/<owner>/<repo>/.bare` and branch worktrees below the
+same repository directory. Branches of that repository should use one GitHub
+account and one Copilot token.
+
+Ordinary repositories can already keep their existing primary-worktree
+authentication in `<repo>/.git/gh`. Existing qwt worktree directories may hold
+different token files, so selecting or copying one automatically would be
+unsafe.
+
+## Decision
+
+- Resolve ordinary repositories from Git's common directory and use its `gh/`
+  child. The primary worktree and all linked worktrees share the same existing
+  `<repo>/.git/gh` directory.
+- Recognize a gh-qwt repository only when the common directory is `.bare/` and
+  its parent contains both `.bare/` and a `.git` pointer to `.bare`. Use that
+  parent's hidden `.gh/` directory as `GH_CONFIG_DIR`.
+- Preserve the existing Git identity, SSH signing key, and Copilot token sync
+  after resolving the shared directory.
+- Do not migrate or merge old worktree-specific authentication files. Users run
+  `gh auth login` once from any existing qwt worktree to initialize the shared
+  `.gh/` directory.
+
+## Alternatives Considered
+
+### Keep worktree-specific authentication
+
+This preserves the previous behavior but requires each gh-qwt branch to be
+authenticated independently. It is not adopted because branch worktrees are
+part of the same repository and should use the same account.
+
+### Use `.bare/gh` for gh-qwt
+
+Git's common directory would make this easy, but it hides authentication inside
+the bare database rather than at the requested repository level. It is not
+adopted because `<qwt_root>/<owner>/<repo>/.gh` is easier to inspect and moves
+with the qwt repository layout.
+
+### Copy an existing worktree's credentials automatically
+
+This could avoid a new login, but old worktrees may contain credentials for
+different accounts. Copying OAuth tokens also creates an unnecessary secret
+selection and duplication path. It is not adopted.
+
+### Limit shared authentication to gh-qwt
+
+Ordinary linked worktrees have the same problem and can share their existing
+primary-worktree authentication through Git's common directory. It is not
+adopted because the generalized behavior preserves ordinary repository
+credentials while making all worktrees consistent.
+
+## Consequences
+
+- Changing branches or moving between linked worktrees no longer prompts for
+  separate authentication within one repository.
+- Existing ordinary repository authentication remains at `<repo>/.git/gh`.
+- Existing qwt repositories need one explicit `gh auth login`; their old
+  worktree-specific credential directories remain untouched.
+- The `.bare/` plus `.git` pointer check avoids treating arbitrary bare
+  repositories as gh-qwt repositories.

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -18,6 +18,7 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 | [0006](./0006-per-app-tmux-sessions.md) | Per-application tmux sessions on terminal launch        | Accepted   |
 | [0007](./0007-gh-wt.md)                 | Manage git worktrees with gh-wt                         | Superseded |
 | [0008](./0008-gh-qwt.md)                | Replace gh-q and gh-wt with gh-qwt                      | Accepted   |
+| [0009](./0009-shared-worktree-gh-auth.md) | Share gh authentication across Git worktrees           | Accepted   |
 
 ## How to Write a New ADR
 

--- a/docs/guides/04-git-identity.md
+++ b/docs/guides/04-git-identity.md
@@ -10,7 +10,7 @@ This page explains the mechanism that automatically switches the GitHub account 
 graph TD
     A[Move directories with `cd`] --> B{Inside a Git repository?}
     B -- No --> U[Unset `GH_CONFIG_DIR`]
-    B -- Yes --> D[Set `GH_CONFIG_DIR` to `.git/gh`]
+    B -- Yes --> D[Resolve repository-shared `GH_CONFIG_DIR`]
     D --> C{GitHub origin?}
     C -- No --> T[Get `gh auth token`]
     C -- Yes --> E{Is local `user.name`/`user.email` already set?}
@@ -35,7 +35,12 @@ graph TD
 
 ### `GH_CONFIG_DIR`
 
-It creates a `.git/gh/` directory in every Git repository and sets the `GH_CONFIG_DIR` environment variable to it. This isolates `gh` authentication data per repository. `GH_CONFIG_DIR` is also set for repositories whose origin is not GitHub, but identity synchronization (below) does not run for them.
+It resolves a repository-shared directory and sets the `GH_CONFIG_DIR` environment variable to it. This isolates `gh` authentication data per repository while allowing linked worktrees to reuse the same account.
+
+- Ordinary Git repositories use `gh/` under Git's common directory. The primary worktree and every linked worktree therefore share `<repo>/.git/gh`.
+- [gh-qwt](../reference/gh-qwt.md) repositories are recognized by their `.bare/` directory and `.git` pointer. Their worktrees share `<qwt_root>/<owner>/<repo>/.gh`.
+
+`GH_CONFIG_DIR` is also set for repositories whose origin is not GitHub, but identity synchronization (below) does not run for them.
 
 ### Automatic Git identity configuration
 
@@ -53,12 +58,13 @@ It creates a `.git/gh/` directory in every Git repository and sets the `GH_CONFI
 
 After updating `GH_CONFIG_DIR`, it gets a token with `gh auth token` and sets it in `COPILOT_GITHUB_TOKEN`. Copilot CLI gives this environment variable higher priority than stored credentials, so it uses the same account as `gh`.
 
-| Situation                              | `GH_CONFIG_DIR` | `COPILOT_GITHUB_TOKEN`                   |
-| -------------------------------------- | --------------- | ---------------------------------------- |
-| Work repository (authenticated)        | `.git/gh`       | Work account token                       |
-| Personal repository (authenticated)    | `.git/gh`       | Personal account token                   |
-| Repository where `gh` is not logged in | `.git/gh`       | unset (falls back to stored credentials) |
-| Outside a Git repository               | unset           | Global `gh` account token                |
+| Situation                               | `GH_CONFIG_DIR`                           | `COPILOT_GITHUB_TOKEN`                   |
+| --------------------------------------- | ----------------------------------------- | ---------------------------------------- |
+| Ordinary repository (authenticated)     | `<repo>/.git/gh`                          | Repository account token                 |
+| Linked worktree (authenticated)         | Primary repository's `.git/gh`            | Same repository account token            |
+| gh-qwt worktree (authenticated)         | `<qwt_root>/<owner>/<repo>/.gh`           | Same repository account token            |
+| Repository where `gh` is not logged in  | Resolved repository-shared directory      | unset (falls back to stored credentials) |
+| Outside a Git repository                | unset                                     | Global `gh` account token                |
 
 ## Relationship with global `.gitconfig`
 
@@ -88,6 +94,17 @@ gh auth status
 
 # If the email scope is required
 gh auth refresh -h github.com -s user:email
+```
+
+### Existing gh-qwt repository authentication
+
+Older gh-qwt worktrees may have authentication files in worktree-specific
+directories. They are not copied automatically because they contain tokens and
+may represent different accounts. From any worktree in the repository, run the
+following once to initialize the shared `.gh/` directory:
+
+```bash
+gh auth login
 ```
 
 ### Signing key cannot be found

--- a/docs/reference/gh-qwt.md
+++ b/docs/reference/gh-qwt.md
@@ -34,11 +34,30 @@ Repository paths omit the host segment and follow `<qwt_root>/<owner>/<repo>/<br
 ~/qwt/cli/cli/
   .bare/              # bare git database (git clone --bare)
   .git                # file containing exactly: gitdir: ./.bare
+  .gh/                # GitHub CLI authentication shared by every worktree
   trunk/              # default-branch worktree, created by `gh qwt get`
   fix/parser/         # feature-branch worktree, created by `gh qwt add`
 ```
 
 The `.git` pointer file uses a relative target (`gitdir: ./.bare`), so the whole repository directory is relocatable as long as `.bare/` and every worktree move together. Branch names containing `/` create nested worktree directories, so a branch named `feat` cannot coexist with a branch named `feat/x` (they need the same path for different purposes).
+
+## GitHub CLI authentication
+
+The `gh-config-dir.zsh` plugin recognizes the `.bare/` directory and `.git`
+pointer created by gh-qwt. It sets `GH_CONFIG_DIR` to the repository-level
+`.gh/` directory, so every branch worktree of the same repository uses the
+same `gh` account and Copilot token.
+
+Authentication stored in older worktree-specific directories is not copied,
+because it can contain tokens for different accounts. In any existing worktree,
+run the following once to initialize the shared `.gh/` directory:
+
+```bash
+gh auth login
+```
+
+See [Automatic Git identity switching](../guides/04-git-identity.md) for the
+full account and signing-key behavior.
 
 ## Usage
 

--- a/docs/reference/zsh/plugins.md
+++ b/docs/reference/zsh/plugins.md
@@ -28,7 +28,7 @@ The most important plugin, which automatically configures GitHub account informa
 Runs automatically on every `cd` via the `chpwd` hook:
 
 1. Check whether the current directory is inside a Git repository
-2. Create `.git/gh/` and set it in `GH_CONFIG_DIR` (isolates `gh` authentication)
+2. Resolve and create a repository-shared `GH_CONFIG_DIR`: ordinary repositories use the common `.git/gh/`, while gh-qwt repositories use `.gh/` at the repository root
 3. Only for GitHub origins, perform the following identity sync:
    - If local `user.name` / `user.email` are not set, fetch them with `gh api` and set them
    - Set `~/.ssh/<login>.pub` as `user.signingkey`
@@ -38,6 +38,7 @@ Runs automatically on every `cd` via the `chpwd` hook:
 
 | Function                    | Description                                                  |
 | --------------------------- | ------------------------------------------------------------ |
+| `resolve_gh_config_dir`     | Resolve shared authentication storage for ordinary and gh-qwt worktrees |
 | `is_github_origin_repo`     | Determine whether `origin` is `github.com`                   |
 | `resolve_gh_identity`       | Get login name, name, and email from `gh api`                |
 | `sync_signing_key_from_gh`  | Set the SSH signing key and `allowed_signers`                |

--- a/dotfiles/zsh/gh-config-dir.zsh
+++ b/dotfiles/zsh/gh-config-dir.zsh
@@ -1,4 +1,20 @@
-# Repository-local GH auth storage (.git/gh) and git identity sync from gh auth.
+# Repository-local GH auth storage shared by linked worktrees and git identity sync from gh auth.
+resolve_gh_config_dir() {
+  local common_git_dir qwt_repo_dir gitdir_pointer
+  common_git_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+
+  qwt_repo_dir="${common_git_dir:h}"
+  if [[ "${common_git_dir:t}" == ".bare" && -d "$qwt_repo_dir/.bare" && -f "$qwt_repo_dir/.git" ]]; then
+    gitdir_pointer="$(<"$qwt_repo_dir/.git")"
+    if [[ "$gitdir_pointer" == "gitdir: ./.bare" || "$gitdir_pointer" == "gitdir: .bare" ]]; then
+      printf '%s\n' "$qwt_repo_dir/.gh"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$common_git_dir/gh"
+}
+
 is_github_origin_repo() {
   local origin_url
   origin_url="$(git config --get remote.origin.url 2>/dev/null || true)"
@@ -129,7 +145,7 @@ sync_git_identity_from_gh() {
 
 set_gh_config_dir() {
   local repo_gh_config
-  repo_gh_config="$(git rev-parse --path-format=absolute --git-path gh 2>/dev/null)" || repo_gh_config=""
+  repo_gh_config="$(resolve_gh_config_dir)" || repo_gh_config=""
 
   if [[ -n "$repo_gh_config" ]]; then
     mkdir -p "$repo_gh_config"


### PR DESCRIPTION
## Purpose

Prevent GitHub CLI authentication from being requested separately for every branch worktree. This change makes all worktrees of one repository reuse the same `gh` account and Copilot token while preserving the existing authentication location for ordinary repositories.

## Background

`gh-config-dir.zsh` previously used Git's worktree-specific `--git-path gh` result. With `gh-qwt`, that path is different for every branch, even though all branches share one repository. The shell hook now resolves authentication storage at the repository scope:

| Repository type | Shared `GH_CONFIG_DIR` |
| --- | --- |
| Ordinary Git repository | `<repo>/.git/gh` |
| `gh-qwt` repository | `<qwt_root>/<owner>/<repo>/.gh` |

```mermaid
flowchart LR
  A[cd into worktree] --> B{gh-qwt layout?}
  B -- Yes --> C[Repository-level .gh]
  B -- No --> D[Git common directory /gh]
  C --> E[Shared gh account and Copilot token]
  D --> E
```

The gh-qwt layout is detected only when `.bare/` and its `.git` pointer are present, so arbitrary bare repositories are not reclassified.

> [!IMPORTANT]
> Existing worktree-specific credentials are not copied or merged because they may belong to different accounts. Run `gh auth login` once from any existing gh-qwt worktree to initialize its shared `.gh/` directory.

## What changed

- Resolve `GH_CONFIG_DIR` from Git's common directory for ordinary linked worktrees.
- Use `<qwt_root>/<owner>/<repo>/.gh` for gh-qwt worktrees.
- Keep Git identity, SSH signing-key, and `COPILOT_GITHUB_TOKEN` synchronization unchanged.
- Document the storage layout, migration behavior, and architecture decision.

## Validation

- `zsh -n dotfiles/zsh/gh-config-dir.zsh`
- Temporary Git fixtures covering ordinary primary/linked worktrees, gh-qwt worktrees, and directories outside Git.
- `bun run docs:build`
