### PR TITLE
feat(starship): warn on stale qwt base branches

### DIFF
--- a/docs/reference/gh-qwt.md
+++ b/docs/reference/gh-qwt.md
@@ -41,6 +41,20 @@ Repository paths omit the host segment and follow `<qwt_root>/<owner>/<repo>/<br
 
 The `.git` pointer file uses a relative target (`gitdir: ./.bare`), so the whole repository directory is relocatable as long as `.bare/` and every worktree move together. Branch names containing `/` create nested worktree directories, so a branch named `feat` cannot coexist with a branch named `feat/x` (they need the same path for different purposes).
 
+## Prompt display
+
+Inside a qwt worktree, the Starship directory segment displays
+`owner/repo/branch`, including when the current directory is below the worktree
+root. It verifies the shared `.bare` directory and `.git` pointer, so ordinary
+Git repositories retain their normal path display. The separate Git branch
+segment displays only the Git icon ``, because this label already includes the
+branch. See [Starship](./starship.md) for the complete prompt behavior.
+
+When `origin/main` is not an ancestor of a qwt worktree's `HEAD`, the prompt
+also shows a yellow ` origin/main +N` warning. `N` is the number of
+`origin/main` commits missing from that worktree; fetch and then merge or rebase
+the remote branch according to the repository workflow.
+
 ## GitHub CLI authentication
 
 The `gh-config-dir.zsh` plugin recognizes the `.bare/` directory and `.git`

--- a/docs/reference/starship.md
+++ b/docs/reference/starship.md
@@ -20,32 +20,42 @@ A two-line prompt composed of Powerline-style gradient segments:
 | Segment                 | Background | Foreground | Contents                                 |
 | ----------------------- | ---------- | ---------- | ---------------------------------------- |
 | Icon                    | `#a3aed2`  | `#090c0c`  | Fixed icon ` `                           |
-| directory               | `#769ff0`  | `#e3e5e5`  | Current directory (up to 3 levels)       |
-| git_branch / git_status | `#394260`  | `#769ff0`  | Branch name + status                     |
+| directory               | `#769ff0`  | `#e3e5e5`  | Current directory or qwt worktree identifier |
+| git_branch / git_status | `#394260`  | `#769ff0`  | Branch name + status, or Git icon + status and base warning for qwt |
 | languages               | `#212736`  | `#769ff0`  | Node.js / Bun / Rust / Go / PHP versions |
 | time                    | `#1d2230`  | `#a0a9cb`  | Current time (`HH:MM`)                   |
 
 ## Module settings
 
-### directory
+### Current directory
 
-| Key                 | Value | Description                                   |
-| ------------------- | ----- | --------------------------------------------- |
-| `truncation_length` | `3`   | Maximum number of directory levels to display |
-| `truncation_symbol` | `…/`  | Symbol used when truncated                    |
+The `custom.cwd` module renders the directory segment. Outside a
+[gh-qwt](./gh-qwt.md) worktree, it keeps every path component: paths inside the
+home directory use `~` as their prefix, while paths outside it remain absolute.
 
-Special directory replacements:
+For a gh-qwt worktree, the shared
+`dotfiles/zsh/starship-qwt-worktree.sh` helper validates the `.bare` directory
+and repository `.git` pointer, then displays `owner/repo/branch`. This applies
+from every subdirectory of the worktree and preserves branch names that contain
+`/`.
 
-| Directory | Display |
-| --------- | ------- |
-| Documents | `󰈙 `    |
-| Downloads | ` `     |
-| Music     | ` `     |
-| Pictures  | ` `     |
+### Git branch
 
-### git_branch
+The `custom.git_branch` module displays the branch in ordinary Git worktrees.
+In gh-qwt worktrees, it displays the Git icon `` without a branch name because
+`custom.cwd` already includes the branch in its `owner/repo/branch` label.
+Detached HEAD states display `HEAD`.
 
-Branch symbol: `` (Nerd Font)
+### qwt base warning
+
+The `custom.qwt_base_warning` module appears in yellow when `origin/main` is
+not an ancestor of the qwt worktree's `HEAD`. Its
+` origin/main +N` label reports the number of commits reachable from
+`origin/main` that the worktree does not contain.
+
+Fetch the remote and then merge or rebase `origin/main` into the worktree
+according to the repository workflow to remove the warning. The module does not
+render until an `origin/main` reference is available locally.
 
 ### Language modules
 

--- a/docs/reference/zsh/plugins.md
+++ b/docs/reference/zsh/plugins.md
@@ -7,6 +7,7 @@ This is the detailed reference for the custom plugins placed in `dotfiles/zsh/`.
 | File                              | Alias | Keybinding | Description                                              |
 | --------------------------------- | ----- | ---------- | -------------------------------------------------------- |
 | `gh-config-dir.zsh`               | —     | —          | Automatically configure Git identity and `GH_CONFIG_DIR` |
+| `starship-qwt-worktree.sh`        | —     | —          | Identify qwt worktrees for the Starship prompt           |
 | `go-to-qwt-repository.zsh`        | `ggr` | `C-]`      | Select a gh-qwt repository/worktree and `cd` into it     |
 | `edit-qwt-repository.zsh`         | `egr` | —          | Select a gh-qwt repository/worktree and open it in `nvim` |
 | `edit-selected-file.zsh`          | `esf` | —          | Select a file and open it in `nvim`                      |
@@ -46,6 +47,19 @@ Runs automatically on every `cd` via the `chpwd` hook:
 | `set_gh_config_dir`         | Set `GH_CONFIG_DIR` and call identity sync                   |
 
 For details, see [Automatic Git identity switching](../../guides/04-git-identity.md).
+
+---
+
+## starship-qwt-worktree.sh
+
+A POSIX helper used by the Starship custom modules. It exits unsuccessfully
+outside a qwt worktree; otherwise, it prints its `owner/repo/branch` label after
+validating the shared `.bare` directory and repository `.git` pointer.
+
+The directory, Git branch, and `origin/main` warning prompt modules share this
+check. As a result, ordinary Git worktrees retain their branch segment, while
+qwt worktrees replace the duplicate branch name with a Git icon and can report a
+stale `origin/main` base.
 
 ---
 

--- a/dotfiles/starship.toml
+++ b/dotfiles/starship.toml
@@ -4,9 +4,10 @@ format = """
 [░▒▓](#a3aed2)\
 [  ](bg:#a3aed2 fg:#090c0c)\
 [](bg:#769ff0 fg:#a3aed2)\
-$directory\
+${custom.cwd}\
 [](fg:#769ff0 bg:#394260)\
-$git_branch\
+${custom.git_branch}\
+${custom.qwt_base_warning}\
 $git_status\
 [](fg:#394260 bg:#212736)\
 $nodejs\
@@ -19,22 +20,54 @@ $time\
 [ ](fg:#1d2230)\
 \n$character"""
 
-[directory]
+[custom.cwd]
+command = '''
+if qwt_worktree_label="$(sh "$HOME/.zsh/starship-qwt-worktree.sh" 2>/dev/null)"; then
+  printf '%s\n' "$qwt_worktree_label"
+  exit 0
+fi
+
+cwd="$(pwd -L)" || exit 1
+case "$cwd" in
+  "$HOME") printf '%s\n' '~' ;;
+  "$HOME"/*) printf '~/%s\n' "${cwd#"$HOME"/}" ;;
+  *) printf '%s\n' "$cwd" ;;
+esac
+'''
+when = true
+shell = ["sh"]
 style = "fg:#e3e5e5 bg:#769ff0"
-format = "[ $path ]($style)"
-truncation_length = 3
-truncation_symbol = "…/"
+format = "[ $output ]($style)"
 
-[directory.substitutions]
-"Documents" = "󰈙 "
-"Downloads" = " "
-"Music" = " "
-"Pictures" = " "
+[custom.git_branch]
+command = '''
+if sh "$HOME/.zsh/starship-qwt-worktree.sh" >/dev/null 2>&1; then
+  printf '%s\n' ''
+  exit 0
+fi
 
-[git_branch]
-symbol = ""
+branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)" || branch="HEAD"
+printf ' %s\n' "$branch"
+'''
+when = "git rev-parse --is-inside-work-tree >/dev/null 2>&1"
+shell = ["sh"]
 style = "bg:#394260"
-format = '[[ $symbol $branch ](fg:#769ff0 bg:#394260)]($style)'
+format = '[[ $output ](fg:#769ff0 bg:#394260)]($style)'
+
+[custom.qwt_base_warning]
+command = '''
+missing_commits="$(git rev-list --count HEAD..origin/main 2>/dev/null)" || exit 1
+printf ' origin/main +%s\n' "$missing_commits"
+'''
+when = '''
+sh "$HOME/.zsh/starship-qwt-worktree.sh" >/dev/null 2>&1 || exit 1
+git rev-parse --verify --quiet origin/main >/dev/null || exit 1
+git merge-base --is-ancestor origin/main HEAD && exit 1
+exit 0
+'''
+shell = ["sh"]
+style = "fg:#e0af68 bg:#394260"
+format = "[ $output ]($style)"
 
 [git_status]
 style = "bg:#394260"

--- a/dotfiles/zsh/starship-qwt-worktree.sh
+++ b/dotfiles/zsh/starship-qwt-worktree.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Print the stable qwt worktree label, or exit unsuccessfully outside qwt.
+common_git_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || exit 1
+[ "${common_git_dir##*/}" = ".bare" ] || exit 1
+
+qwt_repo_dir="${common_git_dir%/.bare}"
+[ -d "$qwt_repo_dir/.bare" ] && [ -f "$qwt_repo_dir/.git" ] || exit 1
+
+gitdir_pointer="$(cat "$qwt_repo_dir/.git" 2>/dev/null)" || exit 1
+case "$gitdir_pointer" in
+  "gitdir: ./.bare" | "gitdir: .bare") ;;
+  *) exit 1 ;;
+esac
+
+worktree="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 1
+case "$worktree" in
+  "$qwt_repo_dir"/*) ;;
+  *) exit 1 ;;
+esac
+
+branch="${worktree#"$qwt_repo_dir"/}"
+repo="${qwt_repo_dir##*/}"
+owner_dir="${qwt_repo_dir%/*}"
+owner="${owner_dir##*/}"
+printf '%s/%s/%s\n' "$owner" "$repo" "$branch"


### PR DESCRIPTION
## Purpose

Make gh-qwt worktrees easier to identify and keep aligned with `origin/main` in the Starship prompt.

## Background

The prompt already renders qwt worktrees as `owner/repo/branch`, so repeating the branch name in the Git segment was redundant. However, a worktree can become stale when `origin/main` advances after it was created. This change keeps the compact Git indicator while surfacing that divergence immediately.

| Context | Directory segment | Git segment |
| --- | --- | --- |
| Ordinary Git repository | `~/...` or absolute path | Git icon + branch name |
| Up-to-date qwt worktree | `owner/repo/branch` | Git icon |
| qwt worktree missing `origin/main` commits | `owner/repo/branch` | Git icon + yellow ` origin/main +N` |

> [!NOTE]
> The warning appears only when a validated qwt worktree has a local `origin/main` ref that is not an ancestor of `HEAD`. `N` is the number of commits reachable from `origin/main` but missing from the worktree.

## Implementation

- Add a shared POSIX qwt-worktree detector for Starship custom modules.
- Replace the built-in directory and branch modules with qwt-aware custom modules.
- Display the Git icon without duplicating the branch in qwt worktrees.
- Add the stale-base warning and document the behavior.

```mermaid
flowchart LR
  A[Starship prompt] --> B{Validated qwt worktree?}
  B -- No --> C[Normal path and branch]
  B -- Yes --> D[owner/repo/branch + Git icon]
  D --> E{origin/main ancestor of HEAD?}
  E -- Yes --> F[No warning]
  E -- No --> G[Yellow origin/main warning]
```

## Validation

- Starship rendering in qwt, ordinary Git, and non-Git directories.
- Isolated qwt fixture where `origin/main` is one commit ahead.
- POSIX helper syntax and diff checks.
