### PR TITLE
chore(skills): adopt qwt worktrees for PR workflows

### DIFF
--- a/docs/development/03-skills-development.md
+++ b/docs/development/03-skills-development.md
@@ -63,6 +63,30 @@ If you see a loading error, check whether the `name` and `description` in the fr
 | State constraints clearly | Prevents infinite loops and destructive operations          |
 | Define the output         | Clarifies what the user can expect                          |
 
+## Branch-workspace skills
+
+When a PR skill needs a branch workspace, use the repository's
+[`gh-qwt`](../reference/gh-qwt.md) workflow instead of changing the branch of
+the invoking checkout.
+
+- Resolve the target worktree with `gh qwt path` and name that path explicitly
+  in subsequent Git commands.
+- Provision a missing repository with `gh qwt get`; provision a missing branch
+  worktree with `gh qwt add`. Refresh `origin` in an existing qwt repository
+  before `add`, because `add` uses cached remote refs. Before editing a reused
+  target, require it to be clean and fast-forward it only when safe.
+- State that `git switch`, `git checkout`, ordinary `git worktree`, and
+  normal-clone fallbacks are prohibited for the skill.
+- Define safe behavior for a dirty source, missing remote branch, path
+  collision, deleted fork, and a worktree that cannot be removed. Preserve
+  recoverable state and stop rather than using destructive recovery commands.
+- If cleanup needs an explicit `owner/repo/branch` argument, run
+  `gh qwt remove` outside a qwt repository, such as from `gh qwt root`.
+
+The restriction belongs in the skill procedure and constraints. Do not add a
+global shell wrapper that blocks ordinary interactive branch operations unless
+that broader behavior is explicitly required.
+
 ## File Placement
 
 ```

--- a/docs/development/99-adr/0010-pr-skills-gh-qwt.md
+++ b/docs/development/99-adr/0010-pr-skills-gh-qwt.md
@@ -1,0 +1,94 @@
+# ADR 0010: Use gh-qwt worktrees for Pull Request skills
+
+Run all Pull Request skill branch workflows in `gh-qwt` worktrees instead of switching branches in a shared checkout.
+
+## Status
+
+Accepted
+
+## Context
+
+The `pr-create` skill previously instructed agents to create and check out a
+feature branch from `main`, while `pr-fix` instructed them to check out the
+Pull Request branch. Those instructions conflict with the repository's
+[`gh-qwt`](../../reference/gh-qwt.md) model: each branch has a separate
+worktree below one shared bare repository.
+
+Using a single checkout for PR work also makes a dirty default branch,
+parallel PR fixes, and branch cleanup during merge unnecessarily fragile. In
+particular, `gh pr merge --delete-branch` cannot safely delete a local branch
+while its worktree remains checked out. When `-R` is required to target a base
+repository, GitHub CLI intentionally skips local branch deletion; for
+cross-repository PRs it also skips remote head deletion.
+
+## Decision
+
+The `pr-create`, `pr-fix`, and `pr-merge` skills use `gh-qwt` as their only
+branch-workspace mechanism.
+
+- Resolve or create a branch worktree with `gh qwt get` and `gh qwt add`, then
+  obtain its absolute path with `gh qwt path`.
+- Run repository commands against the resolved path, using `git -C <path>`
+  where a Git command needs an explicit working directory.
+- Do not run `git switch`, `git checkout`, or a normal-clone branch-switching
+  fallback in these skills. Do not fall back to `git worktree`.
+- When `pr-create` starts with uncommitted changes on the default branch,
+  migrate them only through a reversible, verified transfer to a newly created
+  qwt worktree. Local commits on the default branch are not reset, rebased, or
+  otherwise rewritten automatically.
+- Have `pr-fix` resolve the PR head repository and branch. A fork PR uses a
+  worktree for its head repository; a missing fork or insufficient push access
+  is reported rather than worked around by creating a branch in the base
+  repository.
+- Have `pr-merge` merge with the verified PR head SHA and without
+  `--delete-branch`. After GitHub confirms the merge, remove the clean qwt
+  worktree and local branch with `gh qwt remove --delete-branch` from outside
+  every qwt repository, then delete the head remote branch from its own qwt
+  repository with a lease for the verified head SHA. This works consistently
+  for same-repository and fork PRs without a branch checkout.
+
+This is a skill-level policy. The shell remains free to use normal Git branch
+commands outside the PR skills.
+
+## Alternatives Considered
+
+### Keep branch checkout instructions
+
+This keeps the existing skill text shorter, but places concurrent work and
+dirty default-branch changes in one checkout. It is not adopted because it
+does not use the worktree model established by ADR 0008.
+
+### Fall back to `git worktree` for ordinary clones
+
+This would support legacy clones without provisioning a qwt repository, but it
+would create two competing workspace layouts and inconsistent cleanup
+semantics. It is not adopted; `gh qwt get` provisions the canonical layout
+when needed.
+
+### Block `git switch` and `git checkout` in Zsh
+
+A shell wrapper could make the policy global, but it would alter ordinary Git
+usage and could still be bypassed by another Git executable path. It is not
+adopted because the requirement applies to agent-driven PR workflows, not all
+interactive Git work.
+
+### Require users to prepare every worktree manually
+
+This avoids migration logic, but makes a PR skill fail precisely when it is
+most useful: before its first qwt worktree exists. It is not adopted because
+the skills can provision a worktree deterministically with `gh-qwt`.
+
+## Consequences
+
+- PR work can remain isolated per branch and parallel PR operations do not
+  require a branch switch.
+- A first use from a repository without a qwt checkout may clone the
+  repository into the qwt root.
+- A qwt path conflict, unavailable `gh qwt`, missing or deleted fork, dirty
+  worktree at merge time, or unsafe default-branch migration stops the skill
+  with an actionable error. It must not silently fall back to a checkout.
+- Feature worktrees remain after `pr-fix` for subsequent iterations. A
+  successful `pr-merge` removes the corresponding clean worktree and local
+  branch, then attempts lease-protected head-remote cleanup. A remote cleanup
+  failure is reported without misrepresenting an already merged PR as
+  unmerged.

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -19,6 +19,7 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 | [0007](./0007-gh-wt.md)                 | Manage git worktrees with gh-wt                         | Superseded |
 | [0008](./0008-gh-qwt.md)                | Replace gh-q and gh-wt with gh-qwt                      | Accepted   |
 | [0009](./0009-shared-worktree-gh-auth.md) | Share gh authentication across Git worktrees           | Accepted   |
+| [0010](./0010-pr-skills-gh-qwt.md)        | Use gh-qwt worktrees for Pull Request skills           | Accepted   |
 
 ## How to Write a New ADR
 

--- a/docs/guides/06-skills.md
+++ b/docs/guides/06-skills.md
@@ -6,6 +6,8 @@ This is a guide for getting started quickly with custom Copilot CLI skills.
 
 - dotfiles are already installed (`install.sh` has been run)
 - GitHub Copilot CLI is already installed
+- The `gh-qwt` GitHub CLI extension is available (it is installed by the
+  dotfiles setup)
 
 ## Available skills
 
@@ -14,6 +16,29 @@ This is a guide for getting started quickly with custom Copilot CLI skills.
 | `pr-create` | Automatically creates a draft PR from the current changes                                 |
 | `pr-fix`    | Fixes CI errors, handles reviews, and resolves merge conflicts for the specified PR       |
 | `pr-merge`  | Loops `pr-fix` and Copilot Code Review to zero findings, then approves, waits for CI, and squash merges one or more PRs |
+
+## How PR skills use worktrees
+
+The PR skills do not switch the branch of the checkout where you invoked
+Copilot. They create or reuse a [`gh-qwt`](../reference/gh-qwt.md) worktree
+for the feature or PR head branch, then perform Git operations only in that
+path.
+
+- On a first use, the skill can provision the repository under your qwt root.
+- `pr-create` safely transfers staged, unstaged, and non-ignored untracked
+  changes from a default-branch worktree into the new feature worktree.
+- If the default branch has local commits, the skill stops instead of resetting,
+  rebasing, or pushing that branch automatically.
+- A branch name that collides with another qwt path, such as `feat` and
+  `feat/login`, stops with an error rather than falling back to a branch
+  switch.
+- `pr-fix` works in the PR head worktree, including a fork's repository when
+  applicable. `pr-merge` removes the clean worktree after a successful merge.
+
+> [!IMPORTANT]
+> PR skills intentionally do not use `git switch`, `git checkout`, ordinary
+> `git worktree`, or a normal-clone fallback. This policy applies to the
+> skills; it does not change your normal interactive Git commands.
 
 ## Use `pr-create`
 
@@ -35,9 +60,11 @@ In an interactive session, you can also start it with `/pr create` (described la
 
 1. Checks for a corresponding Task (Issue) and suggests creating one if it does not exist
 2. Reads the diff and comes up with a commit message
-3. Creates and pushes a feature branch
-4. Creates a draft PR
-5. Sets you as the assignee
+3. Creates or reuses an isolated qwt feature worktree and safely moves
+   uncommitted changes there when needed
+4. Commits and pushes the feature branch from that worktree
+5. Creates a draft PR
+6. Sets you as the assignee
 
 ## Use `pr-fix`
 
@@ -49,11 +76,12 @@ In an interactive session, you can also start it with `/pr fix` (described later
 
 ### What happens
 
-1. Detects and resolves merge conflicts
-2. Identifies CI failures from logs and fixes them (repeating until they pass)
-3. Checks review comments and applies reasonable fixes (any comment you reply "対応しない" to is left unchanged, and the reason is recorded in the PR body)
-4. Performs a local review before pushing
-5. Replies to each review comment with what was addressed and resolves the thread
+1. Resolves the PR head repository and creates or reuses its qwt worktree
+2. Detects and resolves merge conflicts
+3. Identifies CI failures from logs and fixes them (repeating until they pass)
+4. Checks review comments and applies reasonable fixes (any comment you reply "対応しない" to is left unchanged, and the reason is recorded in the PR body)
+5. Performs a local review before pushing
+6. Replies to each review comment with what was addressed and resolves the thread
 
 You can also specify a mode:
 
@@ -85,7 +113,8 @@ For each PR number given:
 2. Takes the PR out of Draft and applies the `self approval` label
 3. Waits for the repository's existing self-approval automation to approve the PR (up to 3 minutes)
 4. Waits for CI to go green, going back to step 1 if a merge conflict or a CI failure shows up
-5. Squash merges the PR once everything is green
+5. Squash merges the PR once everything is green, then removes its qwt
+   worktree and branch workspace
 
 If a PR cannot be brought to a mergeable state, it is skipped (with the reason recorded) so the rest of the batch keeps going, and a summary is reported at the end.
 

--- a/docs/reference/gh-qwt.md
+++ b/docs/reference/gh-qwt.md
@@ -107,6 +107,46 @@ gh qwt path cli/cli/fix/parser
 | `gh qwt path [<owner>/<repo>[/<branch>]]` | Print an absolute path (root, repository directory, or worktree path) for `cd` |
 | `gh qwt prune` | Remove worktrees whose branch is gone from the remote, discovered from the current directory |
 
+## Pull Request skill integration
+
+The `pr-create`, `pr-fix`, and `pr-merge` Copilot skills use `gh-qwt` as their
+only branch-workspace mechanism. They do not change the branch of the
+checkout that started the skill.
+
+| PR phase | qwt behavior |
+| --- | --- |
+| Create | Resolve the repository and create a feature worktree. A missing qwt repository is initialized with `get`; a new feature branch is then created with `add`. |
+| Fix | Resolve the PR head repository and branch, including a fork head, then create or reuse that branch's worktree. |
+| Merge | Keep the head worktree through final CI, then remove the clean worktree and local branch after GitHub confirms the squash merge. |
+
+Before `add` is used in an existing qwt repository, the skills fetch
+`origin --prune` from the repository root. `add` relies on cached remote refs,
+so this refresh prevents a newly pushed PR branch from being mistaken for a
+new branch. A missing remote PR branch is created with `get --branch`; a new
+feature branch requires a default-branch `get` followed by `add`. A reused PR
+worktree must be clean and either fast-forward to its remote head or stop on
+an ahead/diverged branch.
+
+When `pr-create` starts from a dirty default branch, it transfers staged,
+unstaged, and non-ignored untracked changes through a named stash and validates
+the target before clearing the source. For an ordinary clone, the stash is
+temporarily bundled into the qwt repository so the index state is preserved.
+If the default branch has local commits or the qwt path is unsafe, the skill
+stops rather than resetting a branch or falling back to a normal checkout.
+
+After a confirmed merge, `pr-merge` removes the worktree and local branch with
+`gh qwt remove --delete-branch`. It runs that command from `gh qwt root`,
+because an `owner/repo/branch` argument is only interpreted as an explicit
+worktree spec outside a qwt repository. It then deletes the head remote branch
+only when its current ref still matches the verified PR head SHA, using a
+lease-protected push. This supports fork PR cleanup without risking deletion
+of a branch that changed after the merge check.
+
+> [!IMPORTANT]
+> PR skills never use `git switch`, `git checkout`, ordinary `git worktree`,
+> or a normal-clone fallback. This constraint applies only to the skills; it
+> does not change interactive Git usage.
+
 ## Shell shortcuts
 
 For interactive shells, this repository provides zsh functions built on `gh qwt list` and `gh qwt root`:

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -6,9 +6,9 @@ This is the specification reference for custom skills.
 
 | Skill       | Description                                                                                                                                  |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pr-create` | Check the corresponding Task, understand the changes, and create a draft PR with an appropriate commit message and description               |
-| `pr-fix`    | Fix CI errors and handle review comments to bring the PR into a mergeable state                                                              |
-| `pr-merge`  | Loop `pr-fix` and Copilot Code Review until there are no findings, then take the PR ready, label it, wait for approval and CI, and squash merge |
+| `pr-create` | Create a draft PR from an isolated `gh-qwt` feature worktree, with an appropriate commit message and description                            |
+| `pr-fix`    | Use the PR head's `gh-qwt` worktree to fix CI errors and handle review comments                                                             |
+| `pr-merge`  | Loop `pr-fix` and Copilot Code Review until there are no findings, then merge and clean up the qwt branch workspace                         |
 
 ## Installation destination
 
@@ -115,17 +115,51 @@ name: Skill name
 | Output               | Recommended | What is shown to the user when the skill finishes    |
 | Hints for developers | Optional    | Example alias configuration, etc.                    |
 
+## PR workspace policy
+
+The three PR skills use [`gh-qwt`](./gh-qwt.md) as their only
+branch-workspace mechanism. A branch is represented by its own worktree, not
+by changing the branch of the invoking checkout.
+
+- The skills resolve a target with `gh qwt path` and run repository commands
+  against that absolute path.
+- A missing qwt repository is provisioned with `gh qwt get`. A missing branch
+  worktree in an existing qwt repository is created with `gh qwt add`.
+  `get --branch` is used only for an existing remote branch; creating a new
+  branch first requires `get` for the default branch, followed by `add`.
+- Before `add` runs in an existing qwt repository, the skills refresh
+  `origin --prune` from the qwt repository root so cached refs cannot turn a
+  just-pushed branch into a mistakenly new branch.
+- Before a PR skill edits a reused target, it requires a clean worktree and
+  either fast-forwards it to its remote head or stops on an ahead/diverged
+  branch. It never silently overwrites an existing worktree.
+- The skill procedures must not use `git switch`, `git checkout`, ordinary
+  `git worktree`, or a normal-clone fallback.
+- If qwt cannot safely create a worktree, such as a slash-prefix path
+  collision, the skill reports the error and stops. It does not change the
+  branch of another checkout as a workaround.
+- This restriction applies to PR skills only. Interactive shell Git commands
+  remain unchanged.
+
+`pr-create` preserves uncommitted source changes through a named stash and
+verification before it clears the source. When the source is a normal clone,
+the stash is transferred as a temporary Git bundle so staged, unstaged, and
+non-ignored untracked changes retain their state in the qwt target. A default
+branch with local commits is intentionally not reset, rebased, or pushed by
+the skill; it stops and asks for explicit direction instead.
+
 ## Detailed specification for `pr-create`
 
 ### Workflow
 
 1. Check the corresponding Task (Issue) (if it cannot be inferred, ask the user to confirm; if there is none, encourage them to create one)
-2. Understand the changes with `git diff` (also refer to the Issue description and comments)
-3. Commit using the Conventional Commits format
-4. Push to the feature branch
-5. Create the PR description (write a readable, visually clear body that fully leverages GFM features such as tables, alerts, Mermaid, and emoji), then create a draft PR with `gh pr create --draft`
-6. Set the invoking user as the Assignee
-7. Finally, update the corresponding Task description to match the final changes (move the original plan to a comment)
+2. Understand the source changes with `git diff` and the Issue description and comments
+3. Resolve or create the feature branch's qwt worktree, migrating uncommitted changes only through the verified preservation procedure
+4. Commit from the target worktree using the Conventional Commits format
+5. Push the target branch
+6. Create the PR description (write a readable, visually clear body that fully leverages GFM features such as tables, alerts, Mermaid, and emoji), then create a draft PR with `gh pr create --draft`
+7. Set the invoking user as the Assignee
+8. Finally, update the corresponding Task description to match the final changes (move the original plan to a comment)
 
 ### Input
 
@@ -140,12 +174,18 @@ name: Skill name
 
 ### Workflow
 
-1. Check the CI status of the specified PR
-2. If there are CI failures, analyze the logs and repeat fixes (up to 3 times)
-3. Retrieve all review comments and judge the validity of each one
-4. Fix valid comments and skip invalid ones; for comments the user replied "対応しない" (will not address) to, record in the PR body that they will not be addressed along with the reason
-5. Before committing and pushing, run a local review with the `code-review` sub-agent
-6. After pushing, reply to each review comment with how it was addressed
+1. Resolve the base repository and the PR head repository / branch, then create or reuse the head qwt worktree
+2. Check the CI status of the specified PR
+3. If there are CI failures, analyze the logs and repeat fixes (up to 3 times)
+4. Retrieve all review comments and judge the validity of each one
+5. Fix valid comments and skip invalid ones; for comments the user replied "対応しない" (will not address) to, record in the PR body that they will not be addressed along with the reason
+6. Before committing and pushing, run a local review with the `code-review` sub-agent
+7. After pushing, reply to each review comment with how it was addressed
+
+The PR API remains scoped to the base repository. Git changes and pushes occur
+only in the head worktree. For a fork PR, the head repository is used as the
+qwt target; a deleted fork or missing push access stops the skill instead of
+creating a substitute branch in the base repository.
 
 ### Input
 
@@ -167,7 +207,17 @@ name: Skill name
 3. Mark the PR ready for review (`gh pr ready`) and apply the `self approval` label
 4. Wait for the pre-existing self-approval automation to approve the PR (short 3-minute timeout, since a miss usually means the automation is not configured)
 5. Wait for CI to go green and re-check mergeability; a merge conflict or a CI failure sends control back to step 1, since `/pr-fix all` can fix both
-6. Once CI is green and there are no conflicts, squash merge (`gh pr merge --squash --delete-branch`)
+6. Once CI is green and there are no conflicts, verify that the qwt worktree
+   is clean and still matches the PR head, squash merge with the checked head
+   SHA, then remove the qwt worktree and local branch with `gh qwt remove
+   --delete-branch`
+
+After the qwt cleanup, `pr-merge` deletes the head remote branch directly from
+its repository only when it still equals the verified PR head SHA. The
+lease-protected deletion works for both same-repository and fork PRs, while
+avoiding the branch checkout that GitHub CLI can otherwise perform during
+local branch deletion. The explicit `gh qwt remove owner/repo/branch` command
+runs from qwt root so its argument cannot be mistaken for a branch name.
 
 Multiple PR numbers are processed one at a time; a PR that fails or times out is skipped (recorded) so the rest of the batch still runs.
 

--- a/dotfiles/skills/pr-create/SKILL.md
+++ b/dotfiles/skills/pr-create/SKILL.md
@@ -7,105 +7,260 @@ description: A skill used when creating a Pull Request. This also applies when `
 
 ## Overview
 
-This is a skill for creating a draft Pull Request (PR).
-It understands staged files and committed changes, then creates the PR with an appropriate commit message and PR description.
+This skill creates a draft Pull Request (PR) from the current changes.
+It uses `gh-qwt` to give the PR branch its own worktree rather than switching
+branches in a shared checkout.
 
 ## When to use
 
 - When asked to "create a PR"
 - When `/pr-create` or `/pr create` is invoked in GitHub Copilot CLI
 
+## Workspace rules
+
+- `gh qwt` is the only workspace mechanism for this skill. If it is
+  unavailable, the repository is not hosted on GitHub, or qwt cannot create
+  the requested path, stop and report the problem.
+- Never run `git switch`, `git checkout`, `git worktree`, or a normal-clone
+  branch-switching fallback. Create and select branches only through
+  `gh qwt get` and `gh qwt add`.
+- Resolve the target with `gh qwt path <owner>/<repo>/<branch>` and run every
+  repository command against that absolute path, for example
+  `git -C "$worktree" status`. Do not rely on the invoking directory after the
+  target worktree has been selected.
+- Never use `git reset --hard`, force-push, or `gh qwt remove --force` to move
+  changes. An unsafe migration must stop with the source worktree or an
+  identifiable stash intact.
+
 ## Procedure
 
 ### Step 1: Check the corresponding Task (GitHub Issue)
 
-- First, check whether there is a GitHub Issue (Task) corresponding to this change
-  - Infer the related issue from the context at skill invocation time, the branch name, commit messages, and so on
-  - If you can infer it, inspect it with `gh issue view <number> --comments` and verify that it matches the changes
-    - Read not only the issue description but also the comments to understand the intent, background, and flow of discussion
-- If the corresponding task cannot be inferred easily, ask the user
-  - Example: "Is there a Task (Issue) associated with this change? If so, please tell me the number."
-- If there is no corresponding task, encourage the user to create one
-  - If creating a task, suggest `gh issue create`
-  - After creating the task, note its number and use it in a later step (`closes #XXX` in the PR description)
+- First, check whether there is a GitHub Issue (Task) corresponding to this
+  change.
+  - Infer the related issue from the context at skill invocation time, the
+    source branch name, commit messages, and so on.
+  - If you can infer it, inspect it with `gh issue view <number> --comments`
+    and verify that it matches the changes.
+  - Read not only the issue description but also the comments to understand
+    the intent, background, and flow of discussion.
+- If the corresponding task cannot be inferred easily, ask the user.
+  - Example: "Is there a Task (Issue) associated with this change? If so,
+    please tell me the number."
+- If there is no corresponding task, encourage the user to create one.
+  - If creating a task, suggest `gh issue create`.
+  - After creating the task, note its number and use it in a later step
+    (`closes #XXX` in the PR description).
 
-### Step 2: Understand the changes deeply
+### Step 2: Understand the source changes deeply
 
-- Run `git diff --staged` or `git diff origin/main..` and review the full diff
-- Read the diff for each file and understand **what** changed and **why**
-  - Always focus on what changes will be applied relative to `origin/main`
-- Consider the context and reasons provided when the skill was invoked
-- When inferring the change details or background, also refer to the corresponding issue description and comments
-- For new files, read the entire file to understand its purpose and role
-- If the changes span multiple logical units, consider splitting them into multiple commits
+- Treat the checkout in which the skill was invoked as the **source
+  worktree**. Record its absolute root, current branch, `HEAD`, staged diff,
+  unstaged diff, untracked-file list, and `git status --porcelain=v1 -z`
+  before changing anything.
+- Read the full staged diff with `git -C <source> diff --staged`, or the
+  committed diff with `git -C <source> diff origin/<default-branch>..`, as
+  appropriate. Resolve the default branch in Step 3 before using the latter
+  command. Always focus on what changes will be applied relative to the remote
+  default branch.
+- Read the diff for each file and understand **what** changed and **why**.
+  For new files, read the entire file to understand its purpose and role.
+- Consider the context and reasons provided when the skill was invoked. When
+  inferring the change details or background, also refer to the corresponding
+  issue description and comments.
+- If the changes span multiple logical units, consider splitting them into
+  multiple commits.
 
-### Step 3: Create a commit message and commit
+### Step 3: Prepare the qwt feature worktree
 
-- Run `git diff --staged --quiet` and commit only when the exit code is 1 (meaning there are staged files)
-- Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
-- Write the commit message in English
-- Check recent commits with `git log --no-merges --oneline -100` and follow the repository conventions
-- **The commit subject must describe the change concretely**
+#### Resolve the repository and source state
+
+1. Confirm that `gh qwt --help` succeeds.
+2. Resolve the canonical GitHub repository and default branch from the source
+   worktree:
+   - `gh repo view --json nameWithOwner,defaultBranchRef`
+   - `git -C <source> branch --show-current`
+   - `git -C <source> rev-parse HEAD`
+3. Stop if `HEAD` is detached, the repository cannot be resolved by `gh`, or
+   the source branch cannot be determined.
+4. Determine whether a qwt repository already exists by checking that
+   `$(gh qwt path <owner>/<repo>)/.bare` is a directory. A normal clone,
+   including an ordinary linked worktree, is not a qwt repository.
+5. Before using `gh qwt add` in an existing qwt repository, refresh its
+   branch metadata with:
+
+   ```bash
+   git -C "$(gh qwt path <owner>/<repo>)" fetch origin --prune
+   ```
+
+   This is the narrow exception to target-worktree command scoping: `gh qwt
+   add` consults cached branch refs and does not fetch them itself.
+
+#### Choose the target branch and create its worktree
+
+- If the source is already the qwt worktree for a non-default feature branch,
+  use that worktree as the target. Verify that its checked-out branch matches
+  the branch name; do not create another worktree.
+- Otherwise, derive a new feature branch name from the change. If the name
+  cannot be inferred safely, ask the user.
+  - The branch name should reflect the changes (for example,
+    `feat/add-pr-create-skill` or `fix/pin-terraform-provider-github-660`).
+  - Map branch prefixes to Conventional Commit types: `feat` -> `feat/*`,
+    `fix` -> `fix/*`, `docs` -> `docs/*`.
+  - Do **not** use `feat/*` or `fix/*` branch names for changes that do not
+    affect the actual product deliverable, such as build tooling, CI/CD
+    configuration, or repository infrastructure. Use an accurate prefix such
+    as `docs/*`, `chore/*`, `ci/*`, or `build/*`.
+- Before migrating a default-branch source, fetch its default branch and
+  compare `HEAD` with `origin/<default-branch>`.
+  - If the default branch has local commits or the base does not match, stop.
+    Do not reset, rebase, or push the default branch automatically.
+  - The target branch must be new. If a local or remote branch with the chosen
+    target name already exists in the qwt repository, stop rather than
+    applying the default-branch changes to it.
+- For a non-default source in an ordinary clone, publish its committed branch
+  with `git -C <source> push --set-upstream origin <source-branch>` before
+  creating its qwt counterpart. This transfers committed work without a
+  checkout. Stop if the push is rejected.
+- If the qwt repository does not yet exist:
+  - For an existing remote target branch from a non-default source, run
+    `gh qwt get <owner>/<repo> --branch <target-branch>`.
+  - For a new target branch, run `gh qwt get <owner>/<repo>` first, then run
+    `gh qwt add --repo <owner>/<repo> <target-branch> --from origin/<default-branch>`.
+- If the qwt repository exists but the target worktree does not, run
+  `gh qwt add --repo <owner>/<repo> <target-branch>`. Add
+  `--from origin/<default-branch>` only when creating a new branch.
+- If a separate target worktree already exists while source changes still
+  need migration, stop rather than applying changes over it. Ask the user to
+  choose a different target or handle the existing worktree.
+- Resolve the target path with `gh qwt path <owner>/<repo>/<target-branch>`
+  and verify it exists and `git -C <target> branch --show-current` equals the
+  target branch.
+- When source and target differ, require
+  `git -C <target> status --porcelain` to be empty, then fetch `origin --prune`
+  in the target. If `origin/<target-branch>` exists, compare it with local
+  `HEAD` before any migration:
+  - If local `HEAD` is behind and the target is clean, fast-forward with
+    `git -C <target> merge --ff-only origin/<target-branch>`.
+  - If local `HEAD` is ahead or diverged, stop rather than applying source
+    changes to a stale or unrelated branch.
+- If `gh qwt` reports a slash-prefix path collision, preserve all source
+  state and stop. Do not work around it with a branch checkout.
+
+#### Migrate uncommitted source changes safely
+
+Skip this subsection when the source and target are the same worktree, or when
+the recorded source status is empty. Otherwise migrate staged, unstaged, and
+non-ignored untracked changes without changing branches.
+
+1. Save the source status, staged binary diff, unstaged binary diff, and
+   non-ignored untracked-file list in a private `mktemp -d` directory. Use
+   these snapshots to validate the target after restoration.
+2. Create a uniquely named stash with `git -C <source> stash push
+   --include-untracked -m "copilot-pr-create-migration-<id>"`. Capture both
+   the resulting stash object ID and a temporary ref such as
+   `refs/copilot/pr-create-migration/<id>` that points to it with
+   `git -C <source> update-ref <temporary-ref> <stash-object-id>`.
+3. If source and target share a qwt common Git directory, restore with
+   `git -C <target> stash apply --index <temporary-ref>`.
+4. If the source is an ordinary clone, export the temporary ref with
+   `git -C <source> bundle create <migration-dir>/migration.bundle <temporary-ref>`,
+   fetch that bundle into the target under the same temporary ref, then run
+   `git -C <target> stash apply --index <temporary-ref>`.
+5. Compare the target's staged binary diff, unstaged binary diff, status, and
+   untracked-file list with the snapshots from step 1. Also confirm that the
+   source worktree is clean after stashing.
+6. Only after all comparisons succeed:
+   - Remove the temporary ref from every repository that received it.
+   - Locate the exact stash reflog entry by its captured object ID and drop
+     that entry. Do not assume it is still `stash@{0}`.
+   - Remove the temporary migration directory.
+7. If creating, fetching, applying, or validating the migration fails, stop
+   immediately. Keep the source stash, temporary ref, and migration artifacts
+   available for recovery, and report their locations. Do not discard changes
+   or continue toward a PR.
+
+### Step 4: Create a commit in the target worktree
+
+- Run `git -C <target> diff --staged --quiet` and commit only when the exit
+  code is 1, meaning staged files exist.
+- Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+  format and write the commit message in English.
+- Check recent commits with `git -C <target> log --no-merges --oneline -100`
+  and follow the repository conventions.
+- The commit subject must describe the change concretely.
   - Bad example: `docs: apply staged changes` (unclear what changed)
   - Bad example: `feat: update files` (too vague)
   - Good example: `feat: allow provided config object to extend other configs`
   - Good example: `fix(github): pin terraform-provider-github version to 6.6.0`
-- The scope indicates the affected area (such as a directory name or action name)
-- Use the imperative mood (`add`, `fix`, `update`) to make the intent clear
-- Add supplementary explanation in the body when needed
-- You may split the work into multiple commits if it helps reviewability or logical separation
+- The scope indicates the affected area, such as a directory name or action
+  name. Use the imperative mood (`add`, `fix`, or `update`) to make the intent
+  clear.
+- Add supplementary explanation in the body when needed. You may split the
+  work into multiple commits if it helps reviewability or logical separation.
 
-### Step 4: Push to a feature branch
+### Step 5: Push the target branch
 
-- If you are currently on `main`, create and check out a feature branch
-- The branch name should reflect the changes (for example, `feat/add-pr-create-skill`, `fix/pin-terraform-provider-github-660`)
-- Map branch prefixes to Conventional Commit types: `feat` -> `feat/*`, `fix` -> `fix/*`, `docs` -> `docs/*`
-- Do **not** use `feat/*` or `fix/*` branch names for changes that do not affect the actual product deliverable (for example, build tooling, CI/CD configuration, or repository infrastructure changes)
-- For non-product-impacting changes, use a branch prefix that matches the real change type (for example, `docs/*`, `chore/*`, `ci/*`, `build/*`)
-- Push with `git push --set-upstream origin <branch>`
-- If you accidentally committed on the local `main` branch, restore it to match `origin/main`
+- Push only from the target worktree with
+  `git -C <target> push --set-upstream origin <target-branch>`.
+- Confirm that the target branch is the branch used for the PR. Never repair
+  an accidental default-branch commit by rewriting the default branch.
 
-### Step 5: Create the PR description and open a draft PR
+### Step 6: Create the PR description and open a draft PR
 
-- If `.github/pull_request_template.md` exists, follow its structure
-- Write the PR body in English
-- **Make full use of GitHub Flavored Markdown (GFM) features** so the body is readable, visually clear, and engaging:
-  - **Tables** to organize structured information such as comparisons, before/after, or summaries of changes
-  - **Alerts** (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) to highlight key points, caveats, and breaking changes
-  - **Mermaid diagrams** to visualize flows, architecture, sequences, or relationships
-  - **Emoji** to add visual cues and make sections easy to scan
-  - Other GFM elements (task lists, collapsible `<details>`, code blocks with language hints, etc.) wherever they aid comprehension
-  - Do not decorate for its own sake — use each element only when it genuinely improves clarity
+- If `.github/pull_request_template.md` exists in the target worktree, follow
+  its structure.
+- Write the PR body in English.
+- **Make full use of GitHub Flavored Markdown (GFM) features** so the body is
+  readable, visually clear, and engaging:
+  - **Tables** to organize structured information such as comparisons,
+    before/after, or summaries of changes.
+  - **Alerts** (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`,
+    and `> [!CAUTION]`) to highlight key points, caveats, and breaking
+    changes.
+  - **Mermaid diagrams** to visualize flows, architecture, or sequences.
+  - **Emoji** to add visual cues and make sections easy to scan.
+  - Other GFM elements, such as task lists, collapsible `<details>`, and
+    language-tagged code blocks, where they improve clarity.
+  - Do not decorate for its own sake; use each element only when it genuinely
+    improves clarity.
 - Include the following in the description:
-  - **Purpose:**
-    - What this PR accomplishes, including not only **what** but also **why**
-    - If there is a task confirmed or created in Step 1, include `closes #XXX`
-  - **Background:**
-    - The reason or context that made this change necessary
-    - Be sure to explain it with a focus on what changes relative to `origin/main`
-- If `CONTRIBUTING.md` exists, follow its guidelines
-- Avoid the following anti-patterns
-  - Simply listing "changed files" as-is (do not write what is already obvious from the diff)
-  - High-context explanations that do not state the reason
-- Create the PR with `gh pr create --draft`
-  - The **PR title** must be in English and follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format: `<type>(<scope>): <description>`
-  - Use `feat` and `fix` **only** when the change directly affects the actual product (deliverable) — i.e., a new feature visible to end users or a bug fix that changes runtime behavior. Do **not** use `feat` or `fix` for changes that have no product impact, such as adding build tooling, fixing CI/CD configuration, or updating repository infrastructure. Use `build`, `ci`, `chore`, or another appropriate type instead.
-  - Map labels to Conventional Commit types: `feat` -> `enhancement`, `fix` -> `bug`
-  - Do **not** use `enhancement` or `bug` labels for new features or bug fixes that do not affect the actual product deliverable (for example, build tooling, CI/CD configuration, or repository infrastructure changes)
-  - For non-product-impacting changes, use labels that match the real change type (for example, `documentation`, `chore`, `ci`, `build`)
+  - **Purpose:** What the PR accomplishes and why. If a task was confirmed or
+    created in Step 1, include `closes #XXX`.
+  - **Background:** The reason or context that made the change necessary,
+    with a focus on what changes relative to the remote default branch.
+- If `CONTRIBUTING.md` exists, follow its guidelines.
+- Avoid simply listing changed files or relying on high-context explanations
+  that omit the reason.
+- Create the PR from the target worktree with `gh pr create --draft`.
+  - The PR title must be in English and follow Conventional Commits:
+    `<type>(<scope>): <description>`.
+  - Use `feat` and `fix` only when the change directly affects the actual
+    product deliverable. For build tooling, CI/CD configuration, or repository
+    infrastructure, use `build`, `ci`, `chore`, or another accurate type.
+  - Map labels to Conventional Commit types: `feat` -> `enhancement` and
+    `fix` -> `bug`.
+  - Do not use `enhancement` or `bug` labels for non-product-impacting
+    changes. Use labels such as `documentation`, `chore`, `ci`, or `build`.
 
-### Step 6: Assign the requesting user
+### Step 7: Assign the requesting user
 
-- Set the user who invoked the skill as the PR assignee
-- Use `gh pr edit <PR_NUMBER> --add-assignee <username>`
+- Set the user who invoked the skill as the PR assignee.
+- Use `gh pr edit <PR_NUMBER> --add-assignee <username>` from the target
+  worktree or with an explicit `-R <owner>/<repo>`.
 
-### Step 7: Align the Issue (Task) description with the final changes
+### Step 8: Align the Issue (Task) description with the final changes
 
-- If there is a corresponding task, update its description so its plan matches the final pull request changes
-- If, after iteration, the issue description no longer matches the actual changes:
-  - Preserve the original plan (the original description) as a comment with `gh issue comment <number>`
-  - Then update the issue description with `gh issue edit <number> --body` so it reflects the actual changes
-- If the description and the actual changes matched from the start, there is no need to rewrite it unnecessarily
+- If there is a corresponding task, update its description so its plan matches
+  the final pull request changes.
+- If, after iteration, the issue description no longer matches the actual
+  changes:
+  - Preserve the original plan as a comment with
+    `gh issue comment <number>`.
+  - Update it with `gh issue edit <number> --body` so it reflects the actual
+    changes.
+- If the description and actual changes matched from the start, do not rewrite
+  it unnecessarily.
 
 ## Output
 

--- a/dotfiles/skills/pr-fix/SKILL.md
+++ b/dotfiles/skills/pr-fix/SKILL.md
@@ -5,61 +5,145 @@ name: pr-fix
 
 # pr-fix
 
-This is a skill for bringing a Pull Request into a mergeable state.
+This skill brings a Pull Request into a mergeable state from its own
+`gh-qwt` worktree.
 
 ## Usage
 
 Invoke it with a PR number and an optional mode:
 
-```
-/pr fix #42              # Fix everything (conflicts → ci → feedback)
+```text
+/pr fix #42              # Fix everything (conflicts -> ci -> feedback)
 /pr fix all #42          # Same as above (explicit mode)
 /pr fix ci #42           # Fix CI failures only
 /pr fix feedback #42     # Handle review comments only
 /pr fix conflicts #42    # Resolve merge conflicts only
 ```
 
+## Prepare the PR worktree
+
+Run this once before the selected mode. It is required even when the invoking
+directory is a different worktree.
+
+1. Confirm that `gh qwt --help` succeeds. Do not use `git switch`,
+   `git checkout`, `git worktree`, or a normal-clone fallback.
+2. Resolve the base repository from the current GitHub repository context, and
+   retrieve the PR explicitly with:
+
+   ```bash
+   gh pr view <PR_NUMBER> -R <base-owner>/<base-repo> \
+     --json headRefName,headRepository,isCrossRepository,baseRefName,url
+   ```
+
+3. Stop and report the error if `headRepository` is null, which commonly
+   means a fork was deleted. Do not create a replacement branch in the base
+   repository.
+4. Set the target repository to `headRepository.nameWithOwner` and the target
+   branch to `headRefName`. This is the branch that will receive fixes. Keep
+   the base repository separately for PR API commands.
+5. Resolve the expected target path with
+   `gh qwt path <head-owner>/<head-repo>/<head-branch>`.
+   - If that worktree exists, verify that
+     `git -C <target> branch --show-current` equals the PR head branch.
+     Inspect `git -C <target> status --porcelain`; if it is not empty, stop
+     and ask the user how to handle the existing changes.
+   - If the qwt repository exists but the worktree does not, first refresh
+     its cached branch refs with
+     `git -C "$(gh qwt path <head-owner>/<head-repo>)" fetch origin --prune`,
+     then create the worktree with
+     `gh qwt add --repo <head-owner>/<head-repo> <head-branch>`.
+   - If the qwt repository does not exist, clone it directly into the PR head
+     branch with
+     `gh qwt get <head-owner>/<head-repo> --branch <head-branch>`.
+   - Resolve the path again with `gh qwt path` and verify both the directory
+     and its checked-out branch.
+6. Fetch `origin --prune` from the resolved target and confirm that
+   `origin/<head-branch>` exists. Compare it with local `HEAD` before
+   editing:
+   - If they match, continue.
+   - If the clean local branch is behind, run
+     `git -C <target> merge --ff-only origin/<head-branch>`.
+   - If local `HEAD` is ahead or diverged, stop rather than overwriting,
+     force-pushing, or working on a stale PR head.
+7. If `gh-qwt` reports a slash-prefix path collision, cannot find the remote
+   branch, or cannot create the worktree, stop and report the qwt error. Do
+   not fall back to a branch checkout.
+8. Inspect `git -C <target> status --porcelain` before changing files. If an
+   existing PR worktree has uncommitted changes, stop and ask the user how to
+   handle them; never use `gh qwt remove --force`.
+9. Verify push access to the head repository before making fixes, for example
+   with `git -C <target> push --dry-run origin <head-branch>`. For a fork PR,
+   this checks access to the fork rather than assuming the base repository is
+   writable. Stop if it is rejected.
+
+All Git commands that inspect, modify, test, commit, or push the PR must use
+the target path. Use `git -C <target> ...` or an equivalent command whose
+working directory is exactly the target worktree. All `gh pr` calls must use
+`-R <base-owner>/<base-repo>` so they continue to address the PR when the
+head is a fork.
+
 ## Modes
 
 ### ci — Fix CI failures
 
-- Retrieve the CI status for the specified PR
-- If any checks are failing, inspect the logs and identify the root cause
-- Apply fixes iteratively until all CI checks pass
-- Commit and push once CI is green
-- If the CI failures cannot be resolved after 3 attempts, stop the work and report the issue
+- Retrieve CI status with `gh pr checks <PR_NUMBER> -R <base-repository>`.
+- If any checks are failing, inspect their logs and identify the root cause.
+- Apply fixes in the target worktree, run the smallest relevant local
+  validation, and repeat until all CI checks pass.
+- Commit and push from the target worktree once CI is green.
+- If the CI failures cannot be resolved after 3 attempts, stop the work and
+  report the issue.
 
 ### conflicts — Resolve merge conflicts
 
-- Fetch the PR base branch and surface conflicts through a rebase or merge
-- Identify all files with conflicts
-- Unless the base branch change is obviously correct, resolve each conflict while preserving the intent of the PR changes
-- Commit the resolved files with a clear message
-- Push the resolved branch
+- Retrieve `baseRefName` and the base repository during workspace preparation.
+- Fetch the PR base into the target worktree. For a same-repository PR, use
+  `origin/<base-ref>`. For a fork PR, configure or reuse an `upstream` remote
+  for the base repository and fetch `upstream/<base-ref>`.
+- Merge the fetched base into the target branch and resolve every conflict
+  while preserving the intent of the PR changes. Prefer a merge over a rebase
+  so the resulting branch can be pushed without force-pushing.
+- Identify all conflicted files. Unless the base-branch change is obviously
+  correct, resolve each conflict deliberately rather than accepting one side
+  wholesale.
+- Commit the resolution with a clear message and push from the target
+  worktree.
 
 ### feedback — Handle review comments
 
-- Retrieve all unresolved review comments on the PR
-  - Be sure to retrieve all replies to the review comments as well
-  - When retrieving review threads via GraphQL, use `reviewThreads(first: 100, after: $cursor)` and inspect `pageInfo { hasNextPage endCursor }` in the response
-  - If `hasNextPage` is `true`, fetch the next page with `after: <endCursor>` and repeat until `hasNextPage` becomes `false`
-- If a comment thread contains a reply from the user stating it will not be addressed (for example, "対応しない"), do not change the code for that comment and skip the validity evaluation below. Instead, append to the PR body that the comment will not be addressed, together with the reason the user gave.
-- For each comment, evaluate whether the feedback is valid:
-  - **Valid** — apply the proposed fix or improvement
-    - If the feedback describes a specific case that causes an error or bug, apply fixes using TDD:
-      1. Write a unit test that reproduces the reported case
-      2. Confirm the unit test fails before making any code changes
-      3. Fix the code until the unit test passes
-  - **Not valid / not applicable** — do not change the code; instead, prepare a reply explaining why
-- After pushing, reply to each comment describing how it was handled:
-  - If fixed: explain the changes that were made
-  - If not fixed: explain why it was judged not applicable
-  - If the user decided not to address it: note that it will not be addressed and that the reason is recorded in the PR body
-- After sending replies, resolve the review comment threads
-- Once all responses are complete, request a review from Copilot Code Review
-  - Get the PR node ID: `gh pr view <PR_NUMBER> --json id -q .id`
-  - Use the retrieved node ID to request a review via a GraphQL mutation:
-    ```
+- Retrieve all unresolved review comments from the base repository.
+  - Retrieve all replies to review comments as well.
+  - When retrieving review threads via GraphQL, use
+    `reviewThreads(first: 100, after: $cursor)` and inspect
+    `pageInfo { hasNextPage endCursor }`.
+  - If `hasNextPage` is `true`, fetch the next page with
+    `after: <endCursor>` and repeat until `hasNextPage` becomes `false`.
+- If a comment thread contains a user reply stating that it will not be
+  addressed, such as "対応しない", do not change the code for that comment and
+  skip the validity evaluation below. Append to the PR body that the comment
+  will not be addressed, together with the user's reason.
+- For each remaining comment, evaluate whether the feedback is valid.
+  - **Valid** — Apply the proposed fix or improvement in the target worktree.
+    If the feedback describes a specific case that causes an error or bug, use
+    TDD:
+    1. Write a unit test that reproduces the reported case.
+    2. Confirm the unit test fails before making code changes.
+    3. Fix the code until the unit test passes.
+  - **Not valid / not applicable** — Do not change the code; prepare a reply
+    explaining why.
+- After pushing, reply to each comment from the base repository, prefixing
+  every comment body with `:robot:`.
+  - If fixed: Explain the changes that were made.
+  - If not fixed: Explain why it was judged not applicable.
+  - If the user decided not to address it: State that it will not be addressed
+    and that the reason is recorded in the PR body.
+- After sending replies, resolve the review comment threads.
+- Once all responses are complete, request a review from Copilot Code Review.
+  - Get the PR node ID with
+    `gh pr view <PR_NUMBER> -R <base-repository> --json id -q .id`.
+  - Use the retrieved node ID to request a review:
+
+    ```bash
     gh api graphql -f query='
     mutation {
       requestReviews(input: {
@@ -80,12 +164,16 @@ Invoke it with a PR number and an optional mode:
       }
     }'
     ```
-  - `BOT_kgDOCnlnWA` is the GraphQL node ID for `copilot-pull-request-reviewer`
-  - The REST API (`gh pr edit --add-reviewer`) cannot be used because bots are rejected as "not a collaborator"
+
+  - `BOT_kgDOCnlnWA` is the GraphQL node ID for
+    `copilot-pull-request-reviewer`.
+  - Do not use `gh pr edit --add-reviewer`: GitHub rejects bots as
+    non-collaborators through that REST API.
 
 ### (default / all) — Fix everything
 
-If no mode is specified, or if `all` is specified, run the three modes in order: **conflicts → ci → feedback**
+If no mode is specified, or if `all` is specified, run the three modes in
+order: **conflicts -> ci -> feedback**.
 
 Conflicts must be resolved first for CI to run correctly.
 
@@ -93,17 +181,26 @@ Conflicts must be resolved first for CI to run correctly.
 
 ### Local review before pushing
 
-- Before committing and pushing changes, run a local code review using a sub-agent (the `code-review` agent type)
-- Confirm there are no significant issues in the local review before committing and pushing
+- Before committing and pushing changes, run a local code review using a
+  sub-agent with the `code-review` agent type.
+- Confirm there are no significant issues in the local review before
+  committing and pushing.
 
 ### Update the PR title and description
 
-- After making fixes and pushing, update the PR title and description so they accurately reflect the current state of the changes
-- Before updating, always retrieve the current title and description with `gh pr view <PR_NUMBER>` and edit based on that content, since someone else may have already updated them
-- Use `gh pr edit <PR_NUMBER> --title` and `gh pr edit <PR_NUMBER> --body` to apply the updates
+- After making fixes and pushing, update the PR title and description so they
+  accurately reflect the current state of the changes.
+- Before updating, always retrieve the current title and description with
+  `gh pr view <PR_NUMBER> -R <base-repository>` and edit based on that
+  content, since someone else may have already updated it.
+- Use `gh pr edit <PR_NUMBER> -R <base-repository> --title` and
+  `gh pr edit <PR_NUMBER> -R <base-repository> --body` to apply the updates.
 
 ## Constraints
 
-- Always work on the PR branch (check out the branch before making changes)
-- Make one commit per logical fix and use a clear message
-- Do not force-push unless explicitly instructed
+- Keep the PR head worktree after the skill completes so a later `pr-fix` or
+  `pr-merge` invocation can reuse it.
+- Make one commit per logical fix and use a clear message.
+- Do not force-push unless explicitly instructed.
+- Do not use a branch checkout, a normal-clone `git worktree`, or a qwt force
+  removal to work around a workspace error.

--- a/dotfiles/skills/pr-merge/SKILL.md
+++ b/dotfiles/skills/pr-merge/SKILL.md
@@ -7,16 +7,26 @@ name: pr-merge
 
 ## Overview
 
-This is a skill for taking one or more Pull Requests from "ready for final review" all the way to "merged". For each PR, it repeatedly runs the `pr-fix` skill and requests a review from Copilot Code Review until there are no unresolved findings, then takes the PR out of Draft, applies the `self approval` label, waits for the pre-existing approval automation and for CI to go green, and finally performs a squash merge.
+This skill takes one or more Pull Requests from "ready for final review" to
+"merged". For each PR, it repeatedly runs `pr-fix` and requests a Copilot Code
+Review until there are no unresolved findings. It then marks the PR ready,
+applies the `self approval` label, waits for approval and CI, and squash
+merges it.
+
+The PR head stays in its own `gh-qwt` worktree throughout review, CI, and the
+merge request. After GitHub confirms the merge, the skill removes the clean
+worktree and its local branch through `gh-qwt`, then deletes the head remote
+branch explicitly.
 
 ## When to use
 
 - When `/pr-merge` is invoked
-- When asked to merge a PR (or several PRs) once review is clean, for example "merge PR #42 once it's ready" or "run these PRs through to merge"
+- When asked to merge a PR (or several PRs) once review is clean, for example
+  "merge PR #42 once it's ready" or "run these PRs through to merge"
 
 ## Usage
 
-```
+```text
 /pr-merge <PR number> [<PR number> ...]
 ```
 
@@ -24,17 +34,44 @@ This is a skill for taking one or more Pull Requests from "ready for final revie
 - Example: `/pr-merge 12 34`
 - PRs are processed one at a time, in the order given
 
+## Workspace rules
+
+- Resolve the base repository for each PR and pass it explicitly as
+  `-R <base-owner>/<base-repo>` to every `gh pr` command.
+- `pr-fix` owns preparation of the PR head worktree. Its `gh-qwt` contract
+  applies to every retry: no `git switch`, `git checkout`, normal-clone
+  fallback, or `git worktree`.
+- Resolve the head repository, head branch, and head SHA again before cleanup
+  with `gh pr view <PR> -R <base-repository> --json
+  headRepository,headRefName,headRefOid`.
+- Use `gh qwt path <head-owner>/<head-repo>/<head-branch>` to locate the
+  worktree. Never infer its path from the current directory.
+- Do not use `gh qwt remove --force`. After a confirmed merge,
+  `gh qwt remove --delete-branch` is the required, safe cleanup operation:
+  it removes the clean worktree before deleting its now-unchecked-out local
+  branch.
+
 ## Procedure (per PR)
 
-Treat steps 1 through 5 below as a single retry loop, capped at **10 iterations**. Two conditions send control back to the top of the loop; everything else either continues normally or stops and reports (see "Retryable vs. non-retryable failures").
+Treat steps 1 through 5 below as a single retry loop, capped at **10
+iterations**. Two conditions send control back to the top of the loop;
+everything else either continues normally or stops and reports (see
+"Retryable vs. non-retryable failures").
 
 ### Step 1: Resolve Copilot Code Review feedback
 
-1. Run `/pr-fix all <PR number>` (fixes merge conflicts, CI failures, and review feedback together)
-2. Request a review from Copilot Code Review, using the same GraphQL mutation as `pr-fix`:
-   - Get the PR node ID: `gh pr view <PR_NUMBER> --json id -q .id`
-   - Request the review:
+1. Run `/pr-fix all <PR number>`. It provisions or reuses the PR head qwt
+   worktree, resolves merge conflicts, CI failures, and review feedback there.
+2. Request a review from Copilot Code Review:
+   - Get the PR node ID:
+
+     ```bash
+     gh pr view <PR_NUMBER> -R <base-repository> --json id -q .id
      ```
+
+   - Request the review:
+
+     ```bash
      gh api graphql -f query='
      mutation {
        requestReviews(input: {
@@ -55,78 +92,171 @@ Treat steps 1 through 5 below as a single retry loop, capped at **10 iterations*
        }
      }'
      ```
-   - `BOT_kgDOCnlnWA` is the GraphQL node ID for `copilot-pull-request-reviewer`
-3. Wait for the review to complete: poll once per minute, up to 30 minutes, for a review from `copilot-pull-request-reviewer` whose `submittedAt` is after the request was sent (check with `gh pr view <PR_NUMBER> --json latestReviews`)
-   - If 30 minutes pass with no review appearing, stop processing this PR and report the timeout (not retryable)
-4. Count the unresolved findings left by Copilot Code Review:
-   - Paginate `reviewThreads(first: 100, after: $cursor)` (same pattern as `pr-fix`'s feedback mode), following `pageInfo { hasNextPage endCursor }` until `hasNextPage` is `false`
-   - For each thread, check `isResolved` and the login of the thread's first comment author
-   - Count the threads where `isResolved` is `false` and the comment author is `copilot-pull-request-reviewer`
-5. If that count is greater than 0, go back to the top of the loop (Step 1)
+
+   - `BOT_kgDOCnlnWA` is the GraphQL node ID for
+     `copilot-pull-request-reviewer`.
+3. Wait for the review to complete: poll once per minute, up to 30 minutes,
+   for a review from `copilot-pull-request-reviewer` whose `submittedAt` is
+   after the request was sent. Use
+   `gh pr view <PR_NUMBER> -R <base-repository> --json latestReviews`.
+4. Count the unresolved Copilot Code Review findings:
+   - Paginate `reviewThreads(first: 100, after: $cursor)`, following
+     `pageInfo { hasNextPage endCursor }` until `hasNextPage` is `false`.
+   - For each thread, check `isResolved` and the login of the thread's first
+     comment author.
+   - Count threads where `isResolved` is `false` and the author is
+     `copilot-pull-request-reviewer`.
+5. If that count is greater than 0, go back to the top of the loop.
 
 ### Step 2: Mark the PR ready for review
 
-- `gh pr ready <PR number>`
-- Idempotent — safe to run again if the loop repeats
+- Run `gh pr ready <PR_NUMBER> -R <base-repository>`.
+- This is idempotent and safe to run again if the loop repeats.
 
 ### Step 3: Apply the `self approval` label
 
-- `gh pr edit <PR number> --add-label "self approval"`
-- The label is expected to already exist in the repository. If `gh` reports that the label does not exist, stop processing this PR immediately and report the error. Do not create the label, and do not retry — this is not something another loop iteration can fix.
+- Run `gh pr edit <PR_NUMBER> -R <base-repository> --add-label "self approval"`.
+- The label is expected to already exist in the repository. If `gh` reports
+  that it does not exist, stop processing this PR immediately and report the
+  error. Do not create the label or retry; another loop iteration cannot fix
+  it.
 
 ### Step 4: Wait for bot approval
 
-- Immediately after applying the label, record the current time
-- Poll once per minute, up to **3 minutes** (3 checks), for a review with `state: APPROVED` whose `submittedAt` is after the recorded time (check with `gh pr view <PR number> --json reviews` or `latestReviews`)
-  - This repository already has a separate, pre-existing automation that approves PRs labeled `self approval`; this skill only waits for its result and does not build or configure that automation
-- If no approval appears within 3 minutes, stop processing this PR immediately and report that the self-approval automation is likely not configured or not running. Do not retry — this short timeout is intentional, to surface that case quickly rather than waiting the full 30 minutes used elsewhere.
+- Immediately after applying the label, record the current time.
+- Poll once per minute, up to **3 minutes** (3 checks), for a review with
+  `state: APPROVED` whose `submittedAt` is after the recorded time. Use
+  `gh pr view <PR_NUMBER> -R <base-repository> --json reviews` or
+  `latestReviews`.
+- If no approval appears within 3 minutes, stop processing this PR immediately
+  and report that the self-approval automation is likely not configured or not
+  running. Do not retry; this short timeout intentionally surfaces that case
+  quickly.
 
-### Step 5: Wait for CI to go green (and re-check mergeability)
+### Step 5: Wait for CI to go green and re-check mergeability
 
 - Poll once per minute, up to 30 minutes, checking both:
-  - `gh pr checks <PR number> --required` for CI status
-  - `gh pr view <PR number> --json mergeable,mergeStateStatus` for merge-conflict status
-- If `mergeable` is `CONFLICTING`, go back to the top of the loop (Step 1) — `/pr-fix all` resolves conflicts as its first phase
-- If any required check's bucket is `fail`, go back to the top of the loop (Step 1) — `/pr-fix all` will attempt to fix the CI failure
-- If 30 minutes pass without reaching a fully green state and without either condition above appearing (for example, checks stuck in `pending`), stop processing this PR immediately and report the timeout (not retryable)
-- If every required check is `pass` (or `skipping`) and `mergeable` shows no conflicts, exit the loop and proceed to Step 6
+  - `gh pr checks <PR_NUMBER> -R <base-repository> --required` for CI status.
+  - `gh pr view <PR_NUMBER> -R <base-repository> --json
+    mergeable,mergeStateStatus,headRefOid` for merge-conflict status and head
+    changes.
+- If `mergeable` is `CONFLICTING`, go back to the top of the loop. `pr-fix`
+  resolves conflicts first.
+- If any required check's bucket is `fail`, go back to the top of the loop.
+  `pr-fix` will attempt to fix the CI failure.
+- If 30 minutes pass without reaching a fully green state and without either
+  condition above appearing, such as checks stuck in `pending`, stop
+  processing this PR and report the timeout.
+- If every required check is `pass` or `skipping` and `mergeable` shows no
+  conflicts, exit the loop and proceed to Step 6.
 
-### Step 6: Squash merge
+### Step 6: Squash merge, then clean up the qwt branch workspace
 
-- `gh pr merge <PR number> --squash --delete-branch`
+1. Retrieve the PR head repository, branch, and SHA again. Stop if the head
+   repository is missing or the PR head changed since the final successful
+   CI/mergeability check.
+2. Resolve the explicit qwt worktree path. Verify all of the following:
+   - The path exists and its current branch is the PR head branch.
+   - `git -C <target> status --porcelain` is empty.
+   - After fetching `origin/<head-branch>`, the local `HEAD`, the
+     `origin/<head-branch>` SHA, and the PR `headRefOid` are identical.
+3. Merge with the checked SHA, without `--delete-branch`:
+
+   ```bash
+   gh pr merge <PR_NUMBER> -R <base-repository> --squash \
+     --match-head-commit <head-ref-oid>
+   ```
+
+4. Confirm that the PR is merged before cleanup. If the merge command fails or
+   the PR remains open, leave the worktree intact and report this PR as
+   failed.
+5. Remove the clean worktree and its local branch:
+
+   ```bash
+   (
+     cd "$(gh qwt root)" &&
+     gh qwt remove <head-owner>/<head-repo>/<head-branch> --delete-branch
+   )
+   ```
+
+   The command must run outside every qwt repository. Inside a qwt worktree,
+   `gh qwt remove` treats its argument as a branch name rather than an
+   explicit `owner/repo/branch` spec. Do not pass `--force`. If the worktree
+   cannot be removed, the PR is already merged; report a cleanup warning with
+   the remaining path instead of reporting a failed merge.
+6. Delete the head branch from its own repository, including for fork PRs:
+
+   ```bash
+   qwt_repo="$(gh qwt path <head-owner>/<head-repo>)"
+   if remote_ref="$(git -C "$qwt_repo" ls-remote origin \
+     "refs/heads/<head-branch>")"; then
+     if [ -n "$remote_ref" ]; then
+       remote_oid="${remote_ref%%[[:space:]]*}"
+       if [ "$remote_oid" = "<head-ref-oid>" ]; then
+         git -C "$qwt_repo" \
+           push --force-with-lease="refs/heads/<head-branch>:<head-ref-oid>" \
+           origin --delete <head-branch>
+       fi
+     fi
+   fi
+   ```
+
+   First distinguish a missing remote ref from an `ls-remote` authentication
+   or network failure; a failed `ls-remote` is a cleanup warning, while a
+   successful empty result is successful cleanup. If `remote_oid` differs
+   from the verified `<head-ref-oid>`, do not run the push: report a cleanup
+   warning because someone updated the branch after the merge check. Run the
+   lease-protected deletion only when the OIDs match. If it fails, report a
+   cleanup warning but retain the merged PR result. The lease is a race guard,
+   not permission to force-update a branch.
 
 ## Retryable vs. non-retryable failures
 
 | Condition | Behavior |
 | --- | --- |
-| Unresolved Copilot Code Review findings (Step 1) | Retryable — back to Step 1 |
-| Merge conflict detected (Step 5) | Retryable — back to Step 1 |
-| CI failure detected (Step 5) | Retryable — back to Step 1 |
+| Unresolved Copilot Code Review findings (Step 1) | Retryable — return to Step 1 |
+| Merge conflict detected (Step 5) | Retryable — return to Step 1 |
+| CI failure detected (Step 5) | Retryable — return to Step 1 |
 | Missing `self approval` label (Step 3) | Not retryable — stop and report |
 | Bot-approval timeout, 3 minutes (Step 4) | Not retryable — stop and report |
 | Review-completion timeout, 30 minutes (Step 1) | Not retryable — stop and report |
 | CI/mergeability-wait timeout, 30 minutes (Step 5) | Not retryable — stop and report |
+| Dirty, missing, or out-of-date qwt worktree (Step 6) | Not retryable — stop and report |
+| Merge request fails or PR remains open (Step 6) | Not retryable — stop and report |
 | Loop exceeds 10 iterations | Not retryable — stop and report |
 
-Because `gh pr ready` and `gh pr edit --add-label` are idempotent, and this repository's branch protection has `dismiss_stale_reviews_on_push: false`, an approval obtained on an earlier iteration is not dismissed by later commits (from a conflict or CI fix made on a later iteration). Re-running Steps 2–4 on a later iteration is therefore safe, and Step 4 in particular typically resolves immediately without any real waiting, since the earlier approval is still valid.
+Because `gh pr ready` and `gh pr edit --add-label` are idempotent, and this
+repository's branch protection has `dismiss_stale_reviews_on_push: false`, an
+approval obtained on an earlier iteration is not dismissed by later commits
+from a conflict or CI fix. Re-running Steps 2 through 4 on a later iteration
+is therefore safe, and Step 4 typically resolves immediately because the
+earlier approval remains valid.
 
 ## Processing multiple PRs
 
-- Run the full per-PR procedure above for each PR number given, in order
-- If a PR fails or times out (per the table above), record the reason, skip it, and continue with the next PR number — do not stop the whole batch
-- After all PR numbers have been processed, report a summary listing, for each PR, either the merged PR's URL or the reason it was not merged
+- Run the full per-PR procedure above for each PR number in order.
+- If a PR fails or times out, record the reason, skip it, and continue with
+  the next PR. Do not stop the whole batch.
+- After all PRs have been processed, report a summary listing each merged PR
+  URL or its failure reason.
 
 ## Constraints
 
-- Polling interval for every waiting step is 1 minute
-- Timeouts: 30 minutes for the review-completion wait (Step 1) and the CI/mergeability wait (Step 5); 3 minutes for the bot-approval wait (Step 4)
-- Maximum 10 iterations of the retry loop per PR
-- Never auto-create the `self approval` label — treat a missing label as a hard error for that PR
-- Building or configuring the approval automation itself is out of scope for this skill; it only waits for the existing mechanism
-- Do not force-push unless explicitly instructed (same constraint as `pr-fix`)
-- Only use squash merges, matching this repository's merge strategy settings (`allow_squash_merge` only)
+- Poll every waiting step once per minute.
+- Time out review completion and CI/mergeability waits after 30 minutes, and
+  bot approval after 3 minutes.
+- Limit the retry loop to 10 iterations per PR.
+- Never auto-create the `self approval` label. A missing label is a hard error
+  for that PR.
+- The approval automation itself is outside this skill's scope; this skill
+  only waits for its result.
+- Do not force-push branch updates unless explicitly instructed. The
+  lease-protected deletion in Step 6 is the sole exception: it deletes only a
+  remote ref that still equals the verified PR head SHA.
+- Only use squash merges, matching this repository's merge strategy settings.
 
 ## Output
 
-- For each PR: the merged PR's URL on success, or the failure reason (which step, and why) if it could not be merged
-- A final summary listing successes and failures across all PR numbers given
+- For each PR: the merged PR URL on success, or the failure reason and step on
+  failure.
+- A final summary across all given PRs.


### PR DESCRIPTION
## Purpose

Adopt `gh-qwt` worktrees for Pull Request automation so the skills never mutate the branch of the checkout that started them.

## Background

The previous PR procedures instructed agents to create or check out branches in a shared working tree. That conflicts with the repository worktree model and makes dirty default branches, parallel PR work, and branch cleanup fragile.

> [!IMPORTANT]
> The PR skills now use `gh qwt` as their only branch-workspace mechanism. A path collision, unsafe migration, missing fork, or stale worktree stops safely instead of falling back to a branch checkout.

## Workflow

```mermaid
flowchart LR
  S[Source checkout] -->|validated migration| W[gh-qwt feature worktree]
  W --> C[Commit and push]
  C --> F[Fix in PR head worktree]
  F --> M[Verify head and squash merge]
  M --> K[Clean qwt workspace]
```

## Changes

| Area | Updated behavior |
| --- | --- |
| `pr-create` | Provisions a feature worktree and preserves staged, unstaged, and untracked changes through a verified migration. |
| `pr-fix` | Resolves the PR head repository, including forks, and applies fixes only in its worktree. |
| `pr-merge` | Merges a verified head, then performs qwt cleanup and lease-protected remote branch deletion. |
| Documentation | Adds ADR 0010 and updates the skills, qwt, user, and contributor references. |

## Safety details

- Default-branch local commits are never reset, rebased, or pushed automatically.
- Existing qwt targets must be clean and current before use.
- Cleanup avoids deleting a remote branch that changed after the merge check.

## Validation

- [x] Built the Docusaurus documentation
- [x] Checked skill frontmatter, qwt command options, prohibited branch-switch instructions, and diff whitespace
- [x] Verified portable stash migration and lease-protected branch deletion behavior
