### PR TITLE
fix(starship): show subdirectory path in qwt-worktree prompt label

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,7 @@ Under `docs/`, place GitHub Flavored Markdown documentation built with Docusauru
 | Docs style         | `docs/development/02-docs-style.md`         | Contributors |
 | ADR index          | `docs/development/99-adr/README.md`         | Contributors |
 | Skills development | `docs/development/03-skills-development.md` | Contributors |
+| Testing            | `docs/development/04-testing.md`            | Contributors |
 
 Style reference to read before editing:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
       - name: Ensure zsh is available
         run: command -v zsh >/dev/null || (sudo apt-get update && sudo apt-get install -y zsh)
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
       - name: Run bats tests
         run: bats tests
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
       - name: Install dependencies
         run: bun install --cwd .docusaurus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+
+      - name: Ensure zsh is available
+        run: command -v zsh >/dev/null || (sudo apt-get update && sudo apt-get install -y zsh)
+
+      - name: Shellcheck (bash/sh scripts)
+        run: shellcheck install.sh scripts/*.sh dotfiles/zsh/starship-qwt-worktree.sh
+
+      - name: Zsh syntax check (zsh plugins)
+        run: |
+          status=0
+          for f in dotfiles/zsh/*.zsh; do
+            zsh -n "$f" || status=1
+          done
+          exit "$status"
+
+      - name: Validate JSON config files
+        run: |
+          jq empty install_map.json
+          jq empty package.json
+          jq empty dotfiles/copilot-hooks/rtk-rewrite.json
+
+      - name: Validate TOML config files
+        run: |
+          python3 -c "
+          import tomllib
+          for f in ['mise.toml', 'dotfiles/starship.toml']:
+              with open(f, 'rb') as fh:
+                  tomllib.load(fh)
+          "
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+
+      - name: Run bats tests
+        run: bats tests
+
+  docs-build:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+
+      - name: Install dependencies
+        run: bun install --cwd .docusaurus
+
+      - name: Build
+        run: bun run --cwd .docusaurus build

--- a/docs/development/01-project-structure.md
+++ b/docs/development/01-project-structure.md
@@ -25,6 +25,7 @@ This page organizes the roles of the repository's main directories and files.
 │   ├── 001-homebrew.sh
 │   ├── 002-brewfile.sh
 │   └── 100-*.sh
+├── tests/                  # bats-core test suite (see docs/development/04-testing.md)
 ├── docs/                   # Documentation
 │   ├── README.mdx
 │   ├── guides/
@@ -36,7 +37,9 @@ This page organizes the roles of the repository's main directories and files.
 │   ├── copilot-instructions.md
 │   ├── dependabot.yml      # Dependency update settings for bun / GitHub Actions
 │   ├── settings.yml        # Declarative repository settings managed by gh-infra
-│   └── workflows/docs.yml
+│   └── workflows/
+│       ├── ci.yml          # Lint, bats tests, and a docs build check
+│       └── docs.yml        # Documentation deploy (main only)
 ├── mise.toml               # Repository-local mise settings
 ├── package.json            # Scripts for building the documentation
 ├── .gitignore              # Definitions for untracked generated and local files
@@ -53,6 +56,7 @@ This page organizes the roles of the repository's main directories and files.
 | `Brewfile`         | List of packages managed by Homebrew                                   | When adding or removing tools                         |
 | `dotfiles/`        | Configuration files that are symlinked                                 | When changing the settings for each tool              |
 | `scripts/`         | Setup scripts                                                          | When changing tool installation procedures            |
+| `tests/`           | bats-core test suite                                                   | When adding logic worth testing, or changing tested behavior |
 | `.devcontainer/`   | Container definitions for GitHub Codespaces                            | When changing the Codespaces environment              |
 | `.gitignore`       | Exclusion settings for files not tracked by Git                        | When adding generated files such as `node_modules/`   |
 
@@ -70,3 +74,13 @@ This page organizes the roles of the repository's main directories and files.
 
 1. `dotfiles/zsh/<name>.zsh` — Create the plugin (`.zshrc` does not need editing; it is sourced automatically)
 2. `docs/reference/zsh/plugins.md` — Update the list
+3. If the plugin has logic that doesn't depend on Homebrew, network access, or fzf/interactive input, consider adding a `tests/<name>.bats` test (see [Testing](./04-testing.md))
+
+### When changing CI or tests
+
+1. `.github/workflows/ci.yml` — Add or change a job/step
+2. `tests/*.bats` — Add or change a test
+3. `mise.toml` — Add any new lint/test tool so CI and local contributors share one version
+4. `docs/development/04-testing.md` — Update the checks table and local run instructions
+5. If the change involves a non-obvious trade-off, record it in `docs/development/99-adr/`
+

--- a/docs/development/02-docs-style.md
+++ b/docs/development/02-docs-style.md
@@ -123,3 +123,4 @@ When making changes, check the following:
 | Changes to scripts             | `reference/scripts.md`                                                               |
 | Adding or changing skills      | `reference/skills.md`, `guides/06-skills.md`, `development/03-skills-development.md` |
 | Changes to Docusaurus settings | `.docusaurus/README.md`                                                              |
+| Changes to CI or tests         | `development/04-testing.md`, `reference/mise.md` (if `mise.toml` tools changed)       |

--- a/docs/development/04-testing.md
+++ b/docs/development/04-testing.md
@@ -1,0 +1,85 @@
+# Testing
+
+This page explains the automated checks that run in CI and how to run each of them locally before opening a pull request.
+
+## Overview
+
+`.github/workflows/ci.yml` runs on every push to `main` and on every pull
+request, with three jobs:
+
+| Job          | Runs on                          | Checks                                                                                 |
+| ------------ | --------------------------------- | --------------------------------------------------------------------------------------- |
+| `lint`       | `ubuntu-slim`                     | `shellcheck` on Bash/sh scripts, `zsh -n` on Zsh plugins, JSON/TOML config syntax        |
+| `test`       | `ubuntu-latest` and `macos-latest` | The `bats-core` suite under `tests/`                                                    |
+| `docs-build` | `ubuntu-slim`                     | Builds the Docusaurus site (build only, no deploy)                                       |
+
+See [ADR 0011](./99-adr/0011-ci-and-shell-testing.md) for why the checks are
+split this way, and what is intentionally left out (a full `scripts/*.sh`
+real-install run).
+
+## Running checks locally
+
+All lint/test tools are managed by [mise](../reference/mise.md), the same way
+`bun` is. Install them once with:
+
+```bash
+mise install
+```
+
+Then, from the repository root:
+
+```bash
+# Shellcheck (Bash/sh scripts only — Zsh plugins use a different check below)
+shellcheck install.sh scripts/*.sh dotfiles/zsh/starship-qwt-worktree.sh
+
+# Zsh syntax check (parse-only, no execution)
+for f in dotfiles/zsh/*.zsh; do zsh -n "$f"; done
+
+# Config file syntax
+jq empty install_map.json
+python3 -c "import tomllib; tomllib.load(open('dotfiles/starship.toml', 'rb'))"
+
+# bats test suite
+bats tests
+
+# Documentation build
+bun install --cwd .docusaurus
+bun run --cwd .docusaurus build
+```
+
+> [!NOTE]
+> `shellcheck` has no Zsh dialect. Running it against `dotfiles/zsh/*.zsh`
+> files would flag valid Zsh-only syntax (for example `${var:h}` or
+> `"$(<file)"`) as errors, so those files are checked with `zsh -n` instead.
+
+## The bats test suite
+
+Tests live under `tests/` as `*.bats` files, with no static fixtures checked
+into the repository — each test builds any git repository or sandbox
+directory it needs at runtime under a temp directory, then tears it down
+afterward. This keeps tests hermetic and independent of the machine running
+them.
+
+Current coverage:
+
+- `tests/starship_qwt_worktree.bats` — `dotfiles/zsh/starship-qwt-worktree.sh`
+  behavior: the `owner/repo/branch` label at a worktree root, the appended
+  subdirectory path from inside a worktree, slash-containing branch names, and
+  the non-zero exit outside a qwt worktree or outside Git entirely.
+- `tests/install_symlinks.bats` — `install.sh`'s symlink-creation logic,
+  exercised against a copy of the real script in an isolated sandbox (fixture
+  `install_map.json` and `dotfiles/`, empty `scripts/` so no real installs
+  run): link creation, idempotent re-runs, and converting a symlinked parent
+  directory into a real one while migrating its existing contents.
+- `tests/install_map.bats` — every `install_map.json` entry resolves to a real
+  path under `dotfiles/`, and every destination looks like an absolute or
+  `~`-rooted path.
+
+### Adding a new test
+
+1. Add a `<name>.bats` file under `tests/` (or a new `@test` block in an
+   existing file, if it belongs with an existing suite)
+2. Prefer testing pure logic that doesn't require Homebrew, network access, or
+   changes to the real machine — build any fixtures the test needs at runtime
+   under a temp directory (see the existing `*.bats` files for the pattern)
+3. Run `bats tests` locally to confirm it passes before opening a pull request

--- a/docs/development/99-adr/0011-ci-and-shell-testing.md
+++ b/docs/development/99-adr/0011-ci-and-shell-testing.md
@@ -1,0 +1,112 @@
+# ADR 0011: Add a CI workflow with bats-core tests and mise-provisioned lint tools
+
+Add `.github/workflows/ci.yml` covering static checks, a bats-core test suite, and a Docusaurus build check, provisioning all lint/test tools through `mise` instead of separate marketplace actions.
+
+## Status
+
+Accepted
+
+## Context
+
+The repository previously had no CI beyond `.github/workflows/docs.yml`, which
+only builds and deploys the documentation site after a push to `main`. There
+was no automated verification of `install.sh`, the setup scripts, or the Zsh
+plugins, and pull requests received no build feedback for documentation
+changes either.
+
+Several constraints shaped the design:
+
+- `dotfiles/zsh/*.zsh` files use Zsh-only syntax (for example `${var:h}`,
+  `${var:t}`, and `"$(<file)"`). `shellcheck` has no Zsh dialect, so running it
+  against `.zsh` files produces false positives on syntax that is valid Zsh
+  but not valid Bash/POSIX sh.
+- `scripts/*.sh` perform real installs (Homebrew, apt, network downloads).
+  Running them end-to-end on every push/PR would make CI slow and dependent on
+  external services staying reachable.
+- `dotfiles/zsh/starship-qwt-worktree.sh` is pure logic driven only by the
+  local Git repository layout, and its behavior interacts with how Git
+  resolves symlinks (`git rev-parse --show-toplevel` resolves them, e.g. macOS
+  `/tmp` → `/private/tmp`), which was the root cause of a real bug fixed
+  shortly before this ADR. That makes it — and `install.sh`'s symlink/migration
+  logic — well suited to hermetic tests that don't touch the real machine.
+- `mise.toml` already manages `bun` for the documentation build, and `docs.yml`
+  already uses `jdx/mise-action@v4` to provision it.
+
+## Decision
+
+- Add `.github/workflows/ci.yml`, triggered on `push` to `main` and on every
+  `pull_request`, with three jobs:
+  - `lint` (`ubuntu-slim` only, since static checks are OS-agnostic and
+    don't need a full-sized runner):
+    `shellcheck` over the Bash/sh scripts (`install.sh`, `scripts/*.sh`,
+    `dotfiles/zsh/starship-qwt-worktree.sh`), `zsh -n` over every
+    `dotfiles/zsh/*.zsh` file, JSON syntax checks (`jq empty`) over
+    `install_map.json`, `package.json`, and
+    `dotfiles/copilot-hooks/rtk-rewrite.json`, and TOML syntax checks (Python's
+    `tomllib`) over `mise.toml` and `dotfiles/starship.toml`.
+  - `test` (matrix of `ubuntu-latest` and `macos-latest`): runs the new
+    `bats-core` suite under `tests/`.
+  - `docs-build` (`ubuntu-slim` only): builds the Docusaurus site
+    (`bun run --cwd .docusaurus build`) without deploying, giving pull requests
+    the build feedback that `docs.yml` only provides after merging to `main`.
+    Uses `ubuntu-slim` to match the runner `docs.yml` already uses for the
+    same build steps.
+- Provision `bats`, `shellcheck`, and `python` (for `tomllib`) via `mise.toml`,
+  the same way `bun` is already managed, and install them in CI with the
+  existing `jdx/mise-action@v4` action. This keeps one source of truth for
+  tool versions for both CI and local contributors (`mise install`), instead of
+  adding a separate marketplace action per tool.
+- Scope automated tests to hermetic, pure-logic behavior:
+  `tests/starship_qwt_worktree.bats` (worktree label formatting, including
+  subdirectories and slash-containing branch names), `tests/install_symlinks.bats`
+  (copies the real `install.sh` into a temp sandbox with a fixture
+  `install_map.json`, fixture `dotfiles/`, and an empty `scripts/` directory so
+  no real installs run, then exercises symlink creation, idempotent re-runs,
+  and the symlinked-parent-directory migration logic), and
+  `tests/install_map.bats` (every `install_map.json` entry resolves to a real
+  path under `dotfiles/`).
+
+## Alternatives Considered
+
+### Run shellcheck against `.zsh` files too
+
+Rejected. `shellcheck` has no Zsh dialect option; forcing `--shell=bash` on
+Zsh-only syntax like `${var:h}` and `"$(<file)"` produces false positives
+rather than real findings. `zsh -n` (Zsh's own parse-only syntax check) is the
+correct tool for `.zsh` files.
+
+### Use `bats-core/bats-action` (or another per-tool marketplace action)
+
+Works, but introduces a second, independent source of truth for tool versions
+alongside `mise.toml`, and doesn't help local contributors run the same
+version. Not adopted — `mise` already manages `bun` for this repository, and
+its registry has entries for `bats`, `shellcheck`, and `python`, so extending
+`mise.toml` keeps versioning and provisioning consistent everywhere.
+
+### Run `scripts/*.sh` end-to-end as a CI smoke test
+
+Would catch real installation regressions, but requires Homebrew/apt/network
+access on every run, is slow, and is flaky when upstream installers or mirrors
+are temporarily unavailable. Not adopted for now; manual verification on a
+real machine remains the way to validate the install scripts themselves. A
+scheduled or manually triggered smoke-test workflow could be added later as a
+separate, explicit decision.
+
+### Enforce shell formatting with `shfmt`
+
+Not requested, and would immediately flag the existing scripts' formatting,
+creating unrelated diff churn unconnected to behavior verification. Not
+adopted.
+
+## Consequences
+
+- Pull requests now get automated feedback on shell script correctness (via
+  `shellcheck`/`zsh -n`), config file syntax (JSON/TOML), the tested logic
+  paths of `install.sh` and `starship-qwt-worktree.sh`, and whether the
+  documentation site still builds.
+- Contributors can run the same checks locally with `mise install` followed by
+  `shellcheck`, `zsh -n`, `bats tests`, and `bun run --cwd .docusaurus build`
+  (see [Testing](../04-testing.md)).
+- `scripts/*.sh` real-install behavior is still only verified by hand on an
+  actual macOS or Codespaces machine; CI does not catch regressions there.
+- `mise.toml` gains `bats`, `shellcheck`, and `python` under `[tools]`.

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -20,6 +20,7 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 | [0008](./0008-gh-qwt.md)                | Replace gh-q and gh-wt with gh-qwt                      | Accepted   |
 | [0009](./0009-shared-worktree-gh-auth.md) | Share gh authentication across Git worktrees           | Accepted   |
 | [0010](./0010-pr-skills-gh-qwt.md)        | Use gh-qwt worktrees for Pull Request skills           | Accepted   |
+| [0011](./0011-ci-and-shell-testing.md)    | Add a CI workflow with bats-core tests and mise-provisioned lint tools | Accepted |
 
 ## How to Write a New ADR
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -10,6 +10,8 @@ This is the developer documentation for changing and extending the dotfiles repo
 
 - [Project Structure](./01-project-structure.md) — Directory structure and the role of each file
 - [Documentation Style](./02-docs-style.md) — Markdown writing conventions
+- [Skills Development](./03-skills-development.md) — How to author and vendor Copilot CLI skills
+- [Testing](./04-testing.md) — CI jobs, the bats test suite, and how to run checks locally
 
 ## Design and Decisions
 

--- a/docs/reference/mise.md
+++ b/docs/reference/mise.md
@@ -25,11 +25,17 @@ As a result, `~/.config/mise/config.toml` becomes a machine-specific file manage
 
 Defines the development environment for the dotfiles repository itself.
 
-| Tool  | Version  | Description                              |
-| ----- | -------- | ---------------------------------------- |
-| `bun` | `latest` | Bun runtime (for building documentation) |
+| Tool         | Version  | Description                                          |
+| ------------ | -------- | ----------------------------------------------------- |
+| `bun`        | `latest` | Bun runtime (for building documentation)              |
+| `bats`       | `latest` | bats-core test runner (for `tests/*.bats`)            |
+| `shellcheck` | `latest` | Shell script linter (for `install.sh`, `scripts/*.sh`) |
+| `python`     | `latest` | Provides a `tomllib`-capable `python3` for CI's TOML checks and `install.sh`'s JSON parsing |
 
 The `[hooks]` section sets `postinstall = "bun install --frozen-lockfile"`, so dependencies are installed automatically after `mise install`.
+
+For how `bats`, `shellcheck`, and `python` are used in CI and how to run the
+same checks locally, see [Testing](../development/04-testing.md).
 
 ### `[settings]` (`mise.toml`)
 

--- a/docs/reference/starship.md
+++ b/docs/reference/starship.md
@@ -38,7 +38,8 @@ For a gh-qwt worktree, the shared
 and repository `.git` pointer, then displays `owner/repo/branch`. From a
 subdirectory of the worktree, it appends the path relative to the worktree
 root as `owner/repo/branch/path/to/subdir`. This preserves branch names that
-contain `/`.
+contain `/`. This behavior is covered by the bats suite — see
+[Testing](../development/04-testing.md).
 
 ### Git branch
 

--- a/docs/reference/starship.md
+++ b/docs/reference/starship.md
@@ -35,9 +35,10 @@ home directory use `~` as their prefix, while paths outside it remain absolute.
 
 For a gh-qwt worktree, the shared
 `dotfiles/zsh/starship-qwt-worktree.sh` helper validates the `.bare` directory
-and repository `.git` pointer, then displays `owner/repo/branch`. This applies
-from every subdirectory of the worktree and preserves branch names that contain
-`/`.
+and repository `.git` pointer, then displays `owner/repo/branch`. From a
+subdirectory of the worktree, it appends the path relative to the worktree
+root as `owner/repo/branch/path/to/subdir`. This preserves branch names that
+contain `/`.
 
 ### Git branch
 

--- a/docs/reference/zsh/plugins.md
+++ b/docs/reference/zsh/plugins.md
@@ -63,6 +63,9 @@ check. As a result, ordinary Git worktrees retain their branch segment, while
 qwt worktrees replace the duplicate branch name with a Git icon and can report a
 stale `origin/main` base.
 
+This script's behavior is covered by the bats suite in `tests/` — see
+[Testing](../../development/04-testing.md).
+
 ---
 
 ## go-to-qwt-repository.zsh

--- a/docs/reference/zsh/plugins.md
+++ b/docs/reference/zsh/plugins.md
@@ -54,7 +54,9 @@ For details, see [Automatic Git identity switching](../../guides/04-git-identity
 
 A POSIX helper used by the Starship custom modules. It exits unsuccessfully
 outside a qwt worktree; otherwise, it prints its `owner/repo/branch` label after
-validating the shared `.bare` directory and repository `.git` pointer.
+validating the shared `.bare` directory and repository `.git` pointer, appending
+the path relative to the worktree root (`owner/repo/branch/path/to/subdir`) when
+run from a subdirectory.
 
 The directory, Git branch, and `origin/main` warning prompt modules share this
 check. As a result, ordinary Git worktrees retain their branch segment, while

--- a/dotfiles/zsh/starship-qwt-worktree.sh
+++ b/dotfiles/zsh/starship-qwt-worktree.sh
@@ -23,4 +23,10 @@ branch="${worktree#"$qwt_repo_dir"/}"
 repo="${qwt_repo_dir##*/}"
 owner_dir="${qwt_repo_dir%/*}"
 owner="${owner_dir##*/}"
-printf '%s/%s/%s\n' "$owner" "$repo" "$branch"
+
+prefix="$(git rev-parse --show-prefix 2>/dev/null)" || exit 1
+if [ -n "$prefix" ]; then
+  printf '%s/%s/%s/%s\n' "$owner" "$repo" "$branch" "${prefix%/}"
+else
+  printf '%s/%s/%s\n' "$owner" "$repo" "$branch"
+fi

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,8 @@
 [tools]
 bun = "latest"
+bats = "latest"
+shellcheck = "latest"
+python = "latest"
 
 [hooks]
 postinstall = "bun install --frozen-lockfile"

--- a/scripts/000-codespace.sh
+++ b/scripts/000-codespace.sh
@@ -8,6 +8,7 @@ if [[ "${os}" == "Darwin" ]]; then
 fi
 
 if [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091 # /etc/os-release only exists on the target Linux host, not statically
   . /etc/os-release
 fi
 

--- a/tests/install_map.bats
+++ b/tests/install_map.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# Referential-integrity checks for install_map.json: guards against typos or
+# stale entries that install.sh would silently mishandle (e.g. linking a
+# source path that doesn't exist under dotfiles/).
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+MAP_FILE="${REPO_ROOT}/install_map.json"
+
+@test "install_map.json is valid JSON with a links object" {
+  run jq -e '.links | type == "object"' "$MAP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "every src entry exists under dotfiles/" {
+  while IFS= read -r src; do
+    [ -e "${REPO_ROOT}/dotfiles/${src}" ]
+  done < <(jq -r '.links | keys[]' "$MAP_FILE")
+}
+
+@test "every dst entry is an absolute or ~-rooted path" {
+  while IFS= read -r dst; do
+    case "$dst" in
+    "~/"* | /*) ;;
+    *) return 1 ;;
+    esac
+  done < <(jq -r '.links | values[]' "$MAP_FILE")
+}

--- a/tests/install_symlinks.bats
+++ b/tests/install_symlinks.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# Behavior tests for the symlink-creation logic in install.sh.
+#
+# Each test copies the real, current install.sh into an isolated sandbox
+# alongside a minimal fixture install_map.json + fixture dotfiles/ + an EMPTY
+# scripts/ directory (so the scripts-running part of install.sh is a no-op —
+# no real installs happen), then runs it with HOME pointed at a temp fake
+# home. This exercises the actual symlink/migration logic without touching
+# the real machine or invoking Homebrew/apt/network.
+
+INSTALL_SH="${BATS_TEST_DIRNAME}/../install.sh"
+
+setup() {
+  ORIGINAL_DIR="$(pwd)"
+  # install.sh resolves its own location with `readlink -f`, so canonicalize
+  # these sandbox paths the same way (e.g. macOS resolves /tmp -> /private/tmp)
+  # to keep path comparisons below consistent with what install.sh sees.
+  SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
+  FAKE_HOME="$(cd "$(mktemp -d)" && pwd -P)"
+
+  mkdir -p "${SANDBOX}/scripts" "${SANDBOX}/dotfiles"
+  cp "${INSTALL_SH}" "${SANDBOX}/install.sh"
+}
+
+teardown() {
+  cd "$ORIGINAL_DIR"
+  rm -rf "$SANDBOX" "$FAKE_HOME"
+}
+
+write_install_map() {
+  # write_install_map '{"a.txt": "~/dst-a.txt", ...}'
+  printf '{"links": %s}\n' "$1" >"${SANDBOX}/install_map.json"
+}
+
+run_install() {
+  HOME="$FAKE_HOME" bash "${SANDBOX}/install.sh"
+}
+
+@test "creates a symlink for each mapping in install_map.json" {
+  mkdir -p "${SANDBOX}/dotfiles/sub"
+  printf 'hello-a\n' >"${SANDBOX}/dotfiles/a.txt"
+  printf 'hello-b\n' >"${SANDBOX}/dotfiles/sub/b.txt"
+  write_install_map '{"a.txt": "~/dst-a.txt", "sub/b.txt": "~/nested/dst-b.txt"}'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+
+  [ -L "${FAKE_HOME}/dst-a.txt" ]
+  [ "$(readlink "${FAKE_HOME}/dst-a.txt")" = "${SANDBOX}/dotfiles/a.txt" ]
+  [ "$(cat "${FAKE_HOME}/dst-a.txt")" = "hello-a" ]
+
+  # ~/nested did not exist beforehand: mkdir -p must have created it.
+  [ -L "${FAKE_HOME}/nested/dst-b.txt" ]
+  [ "$(cat "${FAKE_HOME}/nested/dst-b.txt")" = "hello-b" ]
+}
+
+@test "re-running install.sh is idempotent" {
+  printf 'hello-a\n' >"${SANDBOX}/dotfiles/a.txt"
+  write_install_map '{"a.txt": "~/dst-a.txt"}'
+
+  run run_install
+  [ "$status" -eq 0 ]
+
+  run run_install
+  [ "$status" -eq 0 ]
+
+  [ -L "${FAKE_HOME}/dst-a.txt" ]
+  [ "$(readlink "${FAKE_HOME}/dst-a.txt")" = "${SANDBOX}/dotfiles/a.txt" ]
+}
+
+@test "converts a symlinked parent directory into a real directory and migrates its existing contents" {
+  printf 'fixture-c\n' >"${SANDBOX}/dotfiles/c.txt"
+  write_install_map '{"c.txt": "~/.config/tool/c.txt"}'
+
+  # Pre-existing setup: ~/.config/tool is a symlink to another directory that
+  # already has unrelated content in it.
+  mkdir -p "${FAKE_HOME}/.config" "${FAKE_HOME}/tool-target"
+  printf 'keep-me\n' >"${FAKE_HOME}/tool-target/existing.txt"
+  ln -s "${FAKE_HOME}/tool-target" "${FAKE_HOME}/.config/tool"
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+
+  # The former symlink is now a real directory.
+  [ ! -L "${FAKE_HOME}/.config/tool" ]
+  [ -d "${FAKE_HOME}/.config/tool" ]
+
+  # Pre-existing content was migrated in, not lost.
+  [ -f "${FAKE_HOME}/.config/tool/existing.txt" ]
+  [ "$(cat "${FAKE_HOME}/.config/tool/existing.txt")" = "keep-me" ]
+  [ ! -e "${FAKE_HOME}/tool-target/existing.txt" ]
+
+  # The new mapping was linked inside the now-real directory.
+  [ -L "${FAKE_HOME}/.config/tool/c.txt" ]
+  [ "$(cat "${FAKE_HOME}/.config/tool/c.txt")" = "fixture-c" ]
+}

--- a/tests/starship_qwt_worktree.bats
+++ b/tests/starship_qwt_worktree.bats
@@ -30,16 +30,16 @@ make_qwt_worktree() {
   printf 'gitdir: ./.bare\n' >"$repo_dir/.git"
 
   scratch="$(mktemp -d)"
-  git clone -q "$repo_dir/.bare" "$scratch" >/dev/null 2>&1
+  git clone -q "$repo_dir/.bare" "$scratch"
   (
     cd "$scratch" || exit 1
     git -c commit.gpgsign=false checkout -q -b "$branch"
     git -c commit.gpgsign=false commit -q --allow-empty -m init
     git -c commit.gpgsign=false push -q origin "$branch"
-  ) >/dev/null 2>&1
+  )
   rm -rf "$scratch"
 
-  git -C "$repo_dir" --git-dir=.bare worktree add -q "$branch" "$branch" >/dev/null 2>&1
+  git -C "$repo_dir" --git-dir=.bare worktree add -q "$branch" "$branch"
 }
 
 @test "prints owner/repo/branch at the worktree root" {

--- a/tests/starship_qwt_worktree.bats
+++ b/tests/starship_qwt_worktree.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# Behavior tests for dotfiles/zsh/starship-qwt-worktree.sh.
+#
+# Each test builds its own throwaway git layout under a temp directory, so no
+# fixtures are checked into the repository.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../dotfiles/zsh/starship-qwt-worktree.sh"
+
+setup() {
+  ORIGINAL_DIR="$(pwd)"
+  TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+  cd "$ORIGINAL_DIR"
+  rm -rf "$TEST_TMP"
+}
+
+# Builds a qwt-style bare-repo + worktree layout:
+#   $TEST_TMP/<owner>/<repo>/.bare        bare repository
+#   $TEST_TMP/<owner>/<repo>/.git         "gitdir: ./.bare" pointer file
+#   $TEST_TMP/<owner>/<repo>/<branch>/... worktree for $branch
+make_qwt_worktree() {
+  local owner="$1" repo="$2" branch="$3"
+  local repo_dir="$TEST_TMP/$owner/$repo"
+  local scratch
+
+  mkdir -p "$repo_dir"
+  git init -q --bare "$repo_dir/.bare"
+  printf 'gitdir: ./.bare\n' >"$repo_dir/.git"
+
+  scratch="$(mktemp -d)"
+  git clone -q "$repo_dir/.bare" "$scratch" >/dev/null 2>&1
+  (
+    cd "$scratch" || exit 1
+    git -c commit.gpgsign=false checkout -q -b "$branch"
+    git -c commit.gpgsign=false commit -q --allow-empty -m init
+    git -c commit.gpgsign=false push -q origin "$branch"
+  ) >/dev/null 2>&1
+  rm -rf "$scratch"
+
+  git -C "$repo_dir" --git-dir=.bare worktree add -q "$branch" "$branch" >/dev/null 2>&1
+}
+
+@test "prints owner/repo/branch at the worktree root" {
+  make_qwt_worktree owner repo main
+  cd "$TEST_TMP/owner/repo/main"
+
+  run sh "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "owner/repo/main" ]
+}
+
+@test "appends the relative path from a nested subdirectory" {
+  make_qwt_worktree owner repo main
+  mkdir -p "$TEST_TMP/owner/repo/main/src/lib"
+  cd "$TEST_TMP/owner/repo/main/src/lib"
+
+  run sh "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "owner/repo/main/src/lib" ]
+}
+
+@test "preserves branch names containing a slash" {
+  make_qwt_worktree owner repo feature/foo
+  mkdir -p "$TEST_TMP/owner/repo/feature/foo/subdir"
+  cd "$TEST_TMP/owner/repo/feature/foo/subdir"
+
+  run sh "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "owner/repo/feature/foo/subdir" ]
+}
+
+@test "exits non-zero outside a qwt-managed worktree" {
+  git init -q "$TEST_TMP/plain"
+  cd "$TEST_TMP/plain"
+
+  run sh "$SCRIPT"
+
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "exits non-zero outside any git repository" {
+  mkdir -p "$TEST_TMP/no-git"
+  cd "$TEST_TMP/no-git"
+
+  run sh "$SCRIPT"
+
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}

--- a/tests/starship_qwt_worktree.bats
+++ b/tests/starship_qwt_worktree.bats
@@ -30,16 +30,22 @@ make_qwt_worktree() {
   printf 'gitdir: ./.bare\n' >"$repo_dir/.git"
 
   scratch="$(mktemp -d)"
-  git clone -q "$repo_dir/.bare" "$scratch"
+  git clone -q "$repo_dir/.bare" "$scratch" >/dev/null 2>&1
   (
     cd "$scratch" || exit 1
+    # Some CI runners (e.g. GitHub-hosted ubuntu-latest) have no GECOS full
+    # name for the runner user, so git's fallback identity detection fails
+    # with "empty ident name ... not allowed". Set an explicit local identity
+    # instead of relying on that fallback.
+    git config user.name "qwt-test"
+    git config user.email "qwt-test@example.invalid"
     git -c commit.gpgsign=false checkout -q -b "$branch"
     git -c commit.gpgsign=false commit -q --allow-empty -m init
     git -c commit.gpgsign=false push -q origin "$branch"
-  )
+  ) >/dev/null 2>&1
   rm -rf "$scratch"
 
-  git -C "$repo_dir" --git-dir=.bare worktree add -q "$branch" "$branch"
+  git -C "$repo_dir" --git-dir=.bare worktree add -q "$branch" "$branch" >/dev/null 2>&1
 }
 
 @test "prints owner/repo/branch at the worktree root" {


### PR DESCRIPTION
## Purpose

Fix a Starship prompt bug in `gh qwt`-managed worktrees where moving into a
subdirectory did not update the prompt label, and add automated tests plus a
CI workflow so this fix — and future shell-script changes — can be verified
without manual testing.

## Background

`starship-qwt-worktree.sh` derived the `owner/repo/branch` label solely from
`git rev-parse --show-toplevel` (the worktree root), so the label stayed
fixed even after `cd`-ing into a subdirectory.

| Location                     | Before                | After                                  |
| ----------------------------- | --------------------- | --------------------------------------- |
| Worktree root                 | `owner/repo/branch`   | `owner/repo/branch` (unchanged)         |
| Subdirectory (any depth)      | `owner/repo/branch` ⚠️ stuck at root | `owner/repo/branch/path/to/subdir` |

> [!NOTE]
> The fix uses `git rev-parse --show-prefix` instead of comparing `pwd`
> against the toplevel manually. This also sidesteps a symlink-resolution
> mismatch discovered while testing: `git rev-parse` resolves symlinks (e.g.
> macOS `/tmp` → `/private/tmp`), while `pwd -L` does not — a manual
> string comparison of the two would intermittently fail.

There was also no automated way to verify shell-script changes like this one.
Repo history shows scripts (`dotfiles/zsh/*.zsh`, `install.sh`,
`scripts/*.sh`) were only ever checked by hand, and `docs.yml` only builds
the documentation site after merging to `main`, with no pull-request-time
feedback.

## Implementation

- Rewrite `starship-qwt-worktree.sh` to append the worktree-relative path via
  `git rev-parse --show-prefix`.
- Add `.github/workflows/ci.yml`:

  | Job          | Runs on                             | Checks                                                              |
  | ------------ | ------------------------------------ | -------------------------------------------------------------------- |
  | `lint`       | `ubuntu-slim`                        | `shellcheck` on Bash/sh scripts, `zsh -n` on Zsh plugins, JSON/TOML syntax |
  | `test`       | `ubuntu-latest` and `macos-latest`    | The new `bats-core` suite under `tests/`                              |
  | `docs-build` | `ubuntu-slim`                        | Docusaurus build check (build only, no deploy)                       |

  `ubuntu-slim` matches the runner `docs.yml` already uses for the same kind
  of build-only job; `test` uses both OSes so the symlink-resolution class of
  bug above (and similar cross-platform issues) is caught by CI.
- Add `tests/starship_qwt_worktree.bats`, `tests/install_symlinks.bats`, and
  `tests/install_map.bats` — 11 tests total. Every test builds a synthetic
  Git repo or sandbox under `mktemp -d` and tears it down afterward, so
  nothing touches the real machine or requires real installs
  (Homebrew/apt).
- Provision `bats`, `shellcheck`, and `python` (for `tomllib`) via
  `mise.toml`, consistent with how `bun` is already managed for the docs
  build.
- Fix a real `shellcheck` finding (SC1091) surfaced while wiring up `lint`, in
  `scripts/000-codespace.sh`.
- Pin `jdx/mise-action` to a commit SHA (`@e6a8b39...` / `v4.2.0`) instead of
  the mutable `@v4` tag in `ci.yml`, addressing 3 CodeQL alerts — `jdx` is a
  non-Verified personal GitHub account, so the tag is not a stable
  supply-chain anchor.
- Record the design in
  [ADR 0011](https://github.com/daiksud/dotfiles/blob/main/docs/development/99-adr/0011-ci-and-shell-testing.md)
  and a new [Testing guide](https://github.com/daiksud/dotfiles/blob/main/docs/development/04-testing.md),
  and cross-link both from the docs pages this change touches.

> [!IMPORTANT]
> Out of scope, by design: a full `scripts/*.sh` real-install end-to-end run.
> Those scripts perform real Homebrew/apt installs, which is unsuitable for
> frequent CI; see ADR 0011 for the reasoning and rejected alternatives.

## Validation

- `bats tests` — 11/11 passing on `ubuntu-latest` and `macos-latest` in CI.
  (The `ubuntu-latest` run initially failed: GitHub's hosted runner user has
  no GECOS full name, so git's identity auto-detection fallback produced an
  empty ident and `commit --allow-empty` refused with `fatal: empty ident
  name ... not allowed`. Fixed by setting an explicit, locally-scoped git
  identity in the test fixture's scratch clone.)
- `shellcheck`, `zsh -n`, `jq empty`, and Python `tomllib` checks — all clean.
- `actionlint .github/workflows/ci.yml` — clean.
- `bun run --cwd .docusaurus build` — succeeds with no broken links
  (`onBrokenLinks: "throw"` in `docusaurus.config`).
- Manually verified the prompt fix against a real repo (root + nested
  subdirs), a synthetic repo with a slash-containing branch name, and
  symlinked temp paths.
- All CI checks green: `lint`, `test` (both OSes), `docs-build`, CodeQL,
  code-scanning analysis.
