### PR TITLE
docs(actions): require immutable workflow action pins

### DIFF
--- a/.github/instructions/actions.instructions.md
+++ b/.github/instructions/actions.instructions.md
@@ -9,21 +9,14 @@ applyTo: ".github/workflows/**"
 
 | Category | Pinning method |
 | --- | --- |
-| GitHub-owned | `@vN` (major version pin) |
-| Marketplace badge: “Publisher domain and email verified” | `@vN` (major version pin) |
-| All others (not GitHub-owned and without the Marketplace verified badge) | `@SHA # vX.Y.Z` (SHA pin) |
+| All actions | `@SHA # vX.Y.Z` (full-length commit SHA followed by the release version) |
 
 ```yaml
-# ✅ Good — GitHub-owned / Verified provider
-- uses: actions/checkout@v7
-- uses: slackapi/slack-github-action@v3
-
-# ✅ Good — Non-Verified provider
+# ✅ Good — Full-length SHA pin
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
-# ❌ Bad — SHA pin used for a GitHub-owned / Verified provider
-- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-# ❌ Bad — Major-version pin used for a non-Verified provider
+# ❌ Bad — Mutable major-version tag
+- uses: actions/checkout@v7
 - uses: jdx/mise-action@v4
 ```

--- a/.github/instructions/actions.instructions.md
+++ b/.github/instructions/actions.instructions.md
@@ -7,16 +7,35 @@ applyTo: ".github/workflows/**"
 
 ## Version Pinning Policy
 
-| Category | Pinning method |
+| Reference type | Pinning method |
 | --- | --- |
-| All actions | `@SHA # vX.Y.Z` (full-length commit SHA followed by the release version) |
+| Remote repository action or reusable workflow | `@SHA # vX.Y.Z` (full-length commit SHA followed by the release version) |
+| Local action or reusable workflow (`./...`) | Keep the local path; a ref pin is not applicable |
+| Docker action (`docker://...`) | Pin the image by digest, such as `docker://image@sha256:<digest>` |
 
 ```yaml
-# ✅ Good — Full-length SHA pin
-- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-- uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+# ✅ Good — Remote repository action
+- uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+# ❌ Bad — Mutable remote tag
+- uses: owner/action@v1
+```
 
-# ❌ Bad — Mutable major-version tag
-- uses: actions/checkout@v7
-- uses: jdx/mise-action@v4
+```yaml
+# ✅ Good — Local action
+steps:
+  - uses: ./.github/actions/example
+```
+
+```yaml
+# ✅ Good — Local reusable workflow
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/reusable.yml
+```
+
+```yaml
+# ✅ Good — Docker action
+- uses: docker://example/action@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+# ❌ Bad — Mutable Docker tag
+- uses: docker://example/action:latest
 ```

--- a/.github/instructions/actions.instructions.md
+++ b/.github/instructions/actions.instructions.md
@@ -10,8 +10,8 @@ applyTo: ".github/workflows/**"
 | Category | Pinning method |
 | --- | --- |
 | GitHub-owned | `@vN` (major version pin) |
-| Marketplace Verified Creator | `@vN` (major version pin) |
-| All others (not GitHub-owned and not Verified) | `@SHA # vX.Y.Z` (SHA pin) |
+| Marketplace badge: “Publisher domain and email verified” | `@vN` (major version pin) |
+| All others (not GitHub-owned and without the Marketplace verified badge) | `@SHA # vX.Y.Z` (SHA pin) |
 
 ```yaml
 # ✅ Good — GitHub-owned / Verified provider

--- a/.github/instructions/actions.instructions.md
+++ b/.github/instructions/actions.instructions.md
@@ -21,6 +21,13 @@ applyTo: ".github/workflows/**"
 ```
 
 ```yaml
+# ✅ Good — Remote reusable workflow
+jobs:
+  call-reusable:
+    uses: owner/repository/.github/workflows/reusable.yml@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+```
+
+```yaml
 # ✅ Good — Local action
 steps:
   - uses: ./.github/actions/example

--- a/.github/instructions/actions.instructions.md
+++ b/.github/instructions/actions.instructions.md
@@ -1,0 +1,29 @@
+---
+description: Guidelines for authoring and maintaining GitHub Actions workflows
+applyTo: ".github/workflows/**"
+---
+
+# GitHub Actions Instructions
+
+## Version Pinning Policy
+
+| Category | Pinning method |
+| --- | --- |
+| GitHub-owned (`github_owned_allowed`) | `@vN` (major version pin) |
+| Verified badge (`verified_allowed`) | `@vN` (major version pin) |
+| All others (non-Verified) | `@SHA # vX.Y.Z` (SHA pin) |
+
+```yaml
+# ✅ Good — GitHub-owned / Verified provider
+- uses: actions/checkout@v7
+- uses: slackapi/slack-github-action@v3
+
+# ✅ Good — Non-Verified provider
+- uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+
+# ❌ Bad — SHA pin used for a GitHub-owned / Verified provider
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+# ❌ Bad — Major-version pin used for a non-Verified provider
+- uses: jdx/mise-action@v4
+```

--- a/.github/instructions/actions.instructions.md
+++ b/.github/instructions/actions.instructions.md
@@ -9,9 +9,9 @@ applyTo: ".github/workflows/**"
 
 | Category | Pinning method |
 | --- | --- |
-| GitHub-owned (`github_owned_allowed`) | `@vN` (major version pin) |
-| Verified badge (`verified_allowed`) | `@vN` (major version pin) |
-| All others (non-Verified) | `@SHA # vX.Y.Z` (SHA pin) |
+| GitHub-owned | `@vN` (major version pin) |
+| Marketplace Verified Creator | `@vN` (major version pin) |
+| All others (not GitHub-owned and not Verified) | `@SHA # vX.Y.Z` (SHA pin) |
 
 ```yaml
 # ✅ Good — GitHub-owned / Verified provider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
@@ -56,7 +56,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
@@ -66,7 +66,7 @@ jobs:
   docs-build:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
       - name: Install dependencies
         run: bun install --cwd .docusaurus
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         run: bun run --cwd .docusaurus build
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: .docusaurus/build
 
@@ -44,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/docs/development/01-project-structure.md
+++ b/docs/development/01-project-structure.md
@@ -34,6 +34,8 @@ This page organizes the roles of the repository's main directories and files.
 ├── .devcontainer/          # Codespaces settings
 ├── .docusaurus/            # Docusaurus site build
 ├── .github/
+│   ├── instructions/
+│   │   └── actions.instructions.md # GitHub Actions authoring guidance
 │   ├── copilot-instructions.md
 │   ├── dependabot.yml      # Dependency update settings for bun / GitHub Actions
 │   ├── settings.yml        # Declarative repository settings managed by gh-infra
@@ -58,6 +60,7 @@ This page organizes the roles of the repository's main directories and files.
 | `scripts/`         | Setup scripts                                                          | When changing tool installation procedures            |
 | `tests/`           | bats-core test suite                                                   | When adding logic worth testing, or changing tested behavior |
 | `.devcontainer/`   | Container definitions for GitHub Codespaces                            | When changing the Codespaces environment              |
+| `.github/instructions/` | Scoped instructions for GitHub Actions workflow authoring           | When changing workflow authoring or action pinning guidance |
 | `.gitignore`       | Exclusion settings for files not tracked by Git                        | When adding generated files such as `node_modules/`   |
 
 ## Which Files Should Be Changed Together
@@ -83,4 +86,3 @@ This page organizes the roles of the repository's main directories and files.
 3. `mise.toml` — Add any new lint/test tool so CI and local contributors share one version
 4. `docs/development/04-testing.md` — Update the checks table and local run instructions
 5. If the change involves a non-obvious trade-off, record it in `docs/development/99-adr/`
-

--- a/docs/development/99-adr/0011-ci-and-shell-testing.md
+++ b/docs/development/99-adr/0011-ci-and-shell-testing.md
@@ -30,7 +30,7 @@ Several constraints shaped the design:
   shortly before this ADR. That makes it — and `install.sh`'s symlink/migration
   logic — well suited to hermetic tests that don't touch the real machine.
 - `mise.toml` already manages `bun` for the documentation build, and `docs.yml`
-  already uses `jdx/mise-action@v4` to provision it.
+  already uses the `jdx/mise-action` action to provision it.
 
 ## Decision
 
@@ -53,7 +53,7 @@ Several constraints shaped the design:
     same build steps.
 - Provision `bats`, `shellcheck`, and `python` (for `tomllib`) via `mise.toml`,
   the same way `bun` is already managed, and install them in CI with the
-  existing `jdx/mise-action@v4` action. This keeps one source of truth for
+  existing `jdx/mise-action` action. This keeps one source of truth for
   tool versions for both CI and local contributors (`mise install`), instead of
   adding a separate marketplace action per tool.
 - Scope automated tests to hermetic, pure-logic behavior:

--- a/docs/development/99-adr/0012-github-actions-sha-pinning.md
+++ b/docs/development/99-adr/0012-github-actions-sha-pinning.md
@@ -1,0 +1,60 @@
+# ADR 0012: Require immutable SHA pins for GitHub Actions
+
+Require every GitHub Actions workflow action to reference an immutable commit
+SHA while retaining a human-readable release version comment.
+
+## Status
+
+Accepted
+
+## Context
+
+GitHub Actions references can use mutable major-version tags, release tags, or
+branches. A tag can be moved to a different commit after a workflow is
+reviewed, changing the code that an existing workflow executes. Marketplace
+publisher verification establishes the publisher's identity, but it does not
+make a Git ref immutable.
+
+The repository's workflow guidance therefore needs one rule that applies
+consistently to GitHub-owned actions, verified Marketplace publishers, and all
+other action providers.
+
+## Decision
+
+Every action reference in `.github/workflows/` must use a full-length commit
+SHA followed by a comment containing the corresponding release version:
+
+```yaml
+- uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+```
+
+The SHA is the security control; the version comment makes updates and review
+readable. Publisher verification may inform whether an action is trusted, but
+it does not change the required pinning method.
+
+## Alternatives Considered
+
+### Allow major-version tags for GitHub-owned actions
+
+Major tags are convenient to maintain, but they are mutable and can change the
+workflow's behavior without a pull request. This is not adopted.
+
+### Allow major-version tags for verified Marketplace publishers
+
+Publisher verification confirms identity rather than ref immutability. It does
+not protect a mutable tag from being retargeted or a publisher account from
+being compromised. This is not adopted.
+
+### Allow branch or release tags for all other actions
+
+Branches and release tags are also mutable and provide weaker reproducibility
+than a commit SHA. This is not adopted.
+
+## Consequences
+
+- Workflow dependencies are reproducible and resistant to mutable-ref changes.
+- Updating an action requires resolving and reviewing a new commit SHA.
+- Version comments must stay aligned with the pinned release so humans can
+  identify the dependency without resolving the SHA.
+- Publisher verification no longer creates an exception to the repository-wide
+  pinning rule.

--- a/docs/development/99-adr/0012-github-actions-sha-pinning.md
+++ b/docs/development/99-adr/0012-github-actions-sha-pinning.md
@@ -1,7 +1,7 @@
 # ADR 0012: Require immutable SHA pins for GitHub Actions
 
-Require every GitHub Actions workflow action to reference an immutable commit
-SHA while retaining a human-readable release version comment.
+Require remote GitHub Actions references to use immutable commit SHAs, with
+image digests for Docker actions and path references for local code.
 
 ## Status
 
@@ -9,20 +9,23 @@ Accepted
 
 ## Context
 
-GitHub Actions references can use mutable major-version tags, release tags, or
-branches. A tag can be moved to a different commit after a workflow is
-reviewed, changing the code that an existing workflow executes. Marketplace
+Remote GitHub Actions references can use mutable major-version tags, release
+tags, or branches. A tag can be moved to a different commit after a workflow
+is reviewed, changing the code that an existing workflow executes. Marketplace
 publisher verification establishes the publisher's identity, but it does not
 make a Git ref immutable.
 
 The repository's workflow guidance therefore needs one rule that applies
 consistently to GitHub-owned actions, verified Marketplace publishers, and all
-other action providers.
+other remote action providers. It also needs to explain the immutable form for
+Docker actions and the cases where a commit ref is not part of the syntax, such
+as local actions and local reusable workflows.
 
 ## Decision
 
-Every action reference in `.github/workflows/` must use a full-length commit
-SHA followed by a comment containing the corresponding release version:
+Every remote repository action and reusable workflow reference in
+`.github/workflows/` must use a full-length commit SHA followed by a comment
+containing the corresponding release version:
 
 ```yaml
 - uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3
@@ -31,6 +34,11 @@ SHA followed by a comment containing the corresponding release version:
 The SHA is the security control; the version comment makes updates and review
 readable. Publisher verification may inform whether an action is trusted, but
 it does not change the required pinning method.
+
+Local actions and local reusable workflows referenced with `./...` do not have
+a ref to pin. They remain tied to the checked-out repository contents and are
+subject to normal code review. Docker actions referenced with `docker://...`
+must use an immutable image digest rather than a mutable tag.
 
 ## Alternatives Considered
 
@@ -50,11 +58,20 @@ being compromised. This is not adopted.
 Branches and release tags are also mutable and provide weaker reproducibility
 than a commit SHA. This is not adopted.
 
+### Apply commit-SHA syntax to local or Docker actions
+
+Local references do not accept a commit ref, and Docker actions use image
+references rather than Git refs. This is not adopted; local references remain
+path-based and Docker actions use immutable image digests.
+
 ## Consequences
 
 - Workflow dependencies are reproducible and resistant to mutable-ref changes.
-- Updating an action requires resolving and reviewing a new commit SHA.
+- Updating a remote repository action or reusable workflow requires resolving
+  and reviewing a new commit SHA.
 - Version comments must stay aligned with the pinned release so humans can
   identify the dependency without resolving the SHA.
 - Publisher verification no longer creates an exception to the repository-wide
-  pinning rule.
+  pinning rule for remote repository references.
+- Local actions and reusable workflows require code review instead of ref
+  pinning, and Docker actions require digest updates.

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -21,6 +21,7 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 | [0009](./0009-shared-worktree-gh-auth.md) | Share gh authentication across Git worktrees           | Accepted   |
 | [0010](./0010-pr-skills-gh-qwt.md)        | Use gh-qwt worktrees for Pull Request skills           | Accepted   |
 | [0011](./0011-ci-and-shell-testing.md)    | Add a CI workflow with bats-core tests and mise-provisioned lint tools | Accepted |
+| [0012](./0012-github-actions-sha-pinning.md) | Require immutable SHA pins for GitHub Actions      | Accepted   |
 
 ## How to Write a New ADR
 


### PR DESCRIPTION
## Purpose 🎯
Add repository-level guidance for immutable GitHub Actions references and document how to secure each supported `uses:` form.

> [!IMPORTANT]
> Remote repository actions and reusable workflows under `.github/workflows/**` must use a full-length commit SHA (`@SHA # vX.Y.Z`). Local paths remain path-based, and Docker actions must use immutable image digests. Publisher verification does not create an exception for remote references.

## Background 🧭
Mutable remote action tags can change the code executed by an existing workflow after it has been reviewed. The repository needed one consistent rule for remote providers, plus explicit handling for local actions, local reusable workflows, and Docker actions whose syntax does not accept a Git commit ref.

## What changed

| Area | Change | Why |
| --- | --- | --- |
| `.github/instructions/actions.instructions.md` | Required SHA pins for remote repository references, documented local and Docker forms, and added independent action/reusable-workflow examples | Standardize immutable action references without prescribing invalid syntax |
| `.github/workflows/ci.yml` and `.github/workflows/docs.yml` | Replaced mutable remote action tags with release commit SHAs and version comments | Keep existing workflows compliant with the policy |
| `docs/development/01-project-structure.md` | Documented the new scoped-instructions directory and file | Keep repository layout documentation aligned with the implementation |
| `docs/development/99-adr/0011-ci-and-shell-testing.md` | Removed the obsolete mutable `jdx/mise-action` ref from the CI decision record | Keep historical documentation accurate after pinning |
| `docs/development/99-adr/0012-github-actions-sha-pinning.md` | Recorded the security rationale, scope, and rejected alternatives | Preserve the reasoning behind the repository-wide decision |

```mermaid
flowchart TD
  A[Workflow uses reference] --> B{Reference type}
  B -->|Remote repository| C[Full SHA + version comment]
  B -->|Local path| D[Keep local path]
  B -->|Docker image| E[Image digest]
```

- [x] Added rule metadata (`description`, `applyTo`)
- [x] Required SHA pinning for remote repository references
- [x] Documented local path and Docker digest handling
- [x] Pinned existing workflow action references
- [x] Added independent action and reusable-workflow examples
- [x] Added ADR 0012 and its index entry
- [x] Updated ADR 0011 and project structure documentation

<details>
<summary>Review note</summary>

This change updates action references and documentation only; workflow steps and logic remain unchanged.

</details>
