### PR TITLE
feat(agents): share skills and instructions across coding agents

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - ".github/workflows/**"
+---
+
+@../../.github/workflows/AGENTS.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,78 +1,9 @@
-# Copilot Instructions
+# Copilot Instructions Adapter
 
-## Commit messages
+@../AGENTS.md
 
-- Write in **English**
-- Follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
-  - Example: `feat(starship): add SSH indicator to prompt`
-  - Types: `feat`, `fix`, `docs`, `refactor`, `chore`
+The imported `AGENTS.md` is the canonical repository guidance shared by all
+coding agents.
 
-## Documentation structure
-
-Under `docs/`, place GitHub Flavored Markdown documentation built with Docusaurus:
-
-- `docs/guides/` — user guides (setup and usage)
-- `docs/reference/` — reference (tool list, configuration specs)
-- `docs/development/` — contributor information (structure, style guide)
-- `docs/development/99-adr/` — Architecture Decision Records
-
-### Documentation mapping table
-
-| Topic              | Path                                        | Audience     |
-| ------------------ | ------------------------------------------- | ------------ |
-| Quick start        | `docs/guides/01-quick-start.md`             | Users        |
-| Installation       | `docs/guides/02-installation.md`            | Users        |
-| Link management    | `docs/guides/03-managing-links.md`          | Users        |
-| Git identity       | `docs/guides/04-git-identity.md`            | Users        |
-| How to use skills  | `docs/guides/06-skills.md`                  | Users        |
-| Ghostty            | `docs/reference/ghostty.md`                 | Users        |
-| Git                | `docs/reference/git.md`                     | Users        |
-| mise               | `docs/reference/mise.md`                    | Users        |
-| Neovim             | `docs/reference/nvim.md`                    | Users        |
-| RTK                | `docs/reference/rtk.md`                     | Users        |
-| Sheldon            | `docs/reference/sheldon.md`                 | Users        |
-| Starship           | `docs/reference/starship.md`                | Users        |
-| tmux               | `docs/reference/tmux.md`                    | Users        |
-| Zsh                | `docs/reference/zsh/README.md`              | Users        |
-| Zsh plugins        | `docs/reference/zsh/plugins.md`             | Users        |
-| install_map.json   | `docs/reference/install-map.md`             | Users        |
-| gh-infra           | `docs/reference/gh-infra.md`                | Users        |
-| gh-qwt             | `docs/reference/gh-qwt.md`                  | Users        |
-| Scripts            | `docs/reference/scripts.md`                 | Users        |
-| Tools (Brewfile)   | `docs/reference/tools.md`                   | Users        |
-| Copilot Skills     | `docs/reference/skills.md`                  | Users        |
-| Project structure  | `docs/development/01-project-structure.md`  | Contributors |
-| Docs style         | `docs/development/02-docs-style.md`         | Contributors |
-| ADR index          | `docs/development/99-adr/README.md`         | Contributors |
-| Skills development | `docs/development/03-skills-development.md` | Contributors |
-| Testing            | `docs/development/04-testing.md`            | Contributors |
-
-Style reference to read before editing:
-
-- `docs/development/02-docs-style.md` — documentation writing style guide
-
-## Required workflow
-
-1. Before editing code, always read the related documents under `docs/` (at minimum, the relevant section `README` and related pages).
-2. Before editing documentation, always read `docs/development/02-docs-style.md` to understand the documentation policy and conventions.
-3. When changing code, scripts, or configuration, always update `docs/` in the same change. For the change checklist and scope mapping, refer to the "Documentation Strategy" section of `docs/development/02-docs-style.md`.
-4. After making changes, always verify documentation accuracy, link integrity, and coverage against the current implementation.
-5. If the current document structure is hard to understand, reorganize it as needed.
-6. Always keep documentation aligned with the current implementation. Do not defer updates to a later commit.
-7. If there are multiple options for architecture or technical choices, always record them in `docs/development/99-adr/`.
-
-## Docusaurus conventions
-
-- Add a numeric prefix in the `01-` format to filenames for sidebar ordering
-- Do not add numeric prefixes to section directories (`guides/`, `reference/`, `development/`)
-- Use each directory's `README.md` as the index page
-- Write links as relative paths with the `.md` extension
-- Start each page with a `# h1` title, followed by an explanatory paragraph
-
-## Required quality standards
-
-- Documentation must always state **what changed**, **why it changed**, and **how to operate it**
-- Make examples and commands ready to copy and use as-is
-- Avoid outdated guidance and duplicated guidance
-- **Never copy source code or configuration into documentation.** Reproducing real source or config files causes double maintenance and stale docs. Describe the behavior and link to the source file (for example, `dotfiles/zshrc`) instead. Only examples or sample snippets that are not maintained elsewhere belong in docs. See the "Source Code in Documentation" section of `docs/development/02-docs-style.md`
-- Include clear reasons in records of decisions
+When editing files under `.github/workflows/`, also follow the scoped guidance
+in [`.github/workflows/AGENTS.md`](workflows/AGENTS.md).

--- a/.github/instructions/actions.instructions.md
+++ b/.github/instructions/actions.instructions.md
@@ -5,44 +5,5 @@ applyTo: ".github/workflows/**"
 
 # GitHub Actions Instructions
 
-## Version Pinning Policy
-
-| Reference type | Pinning method |
-| --- | --- |
-| Remote repository action or reusable workflow | `@SHA # vX.Y.Z` (full-length commit SHA followed by the release version) |
-| Local action or reusable workflow (`./...`) | Keep the local path; a ref pin is not applicable |
-| Docker action (`docker://...`) | Pin the image by digest, such as `docker://image@sha256:<digest>` |
-
-```yaml
-# ✅ Good — Remote repository action
-- uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3
-# ❌ Bad — Mutable remote tag
-- uses: owner/action@v1
-```
-
-```yaml
-# ✅ Good — Remote reusable workflow
-jobs:
-  call-reusable:
-    uses: owner/repository/.github/workflows/reusable.yml@0123456789abcdef0123456789abcdef01234567 # v1.2.3
-```
-
-```yaml
-# ✅ Good — Local action
-steps:
-  - uses: ./.github/actions/example
-```
-
-```yaml
-# ✅ Good — Local reusable workflow
-jobs:
-  call-reusable:
-    uses: ./.github/workflows/reusable.yml
-```
-
-```yaml
-# ✅ Good — Docker action
-- uses: docker://example/action@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-# ❌ Bad — Mutable Docker tag
-- uses: docker://example/action:latest
-```
+Read and follow the canonical workflow guidance in
+[`../workflows/AGENTS.md`](../workflows/AGENTS.md).

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,45 @@
+# GitHub Actions Instructions
+
+Follow these rules when authoring or maintaining GitHub Actions workflows.
+
+## Version pinning policy
+
+| Reference type | Pinning method |
+| --- | --- |
+| Remote repository action or reusable workflow | `@SHA # vX.Y.Z` (full-length commit SHA followed by the release version) |
+| Local action or reusable workflow (`./...`) | Keep the local path; a ref pin is not applicable |
+| Docker action (`docker://...`) | Pin the image by digest, such as `docker://image@sha256:<digest>` |
+
+```yaml
+# ✅ Good — Remote repository action
+- uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+# ❌ Bad — Mutable remote tag
+- uses: owner/action@v1
+```
+
+```yaml
+# ✅ Good — Remote reusable workflow
+jobs:
+  call-reusable:
+    uses: owner/repository/.github/workflows/reusable.yml@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+```
+
+```yaml
+# ✅ Good — Local action
+steps:
+  - uses: ./.github/actions/example
+```
+
+```yaml
+# ✅ Good — Local reusable workflow
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/reusable.yml
+```
+
+```yaml
+# ✅ Good — Docker action
+- uses: docker://example/action@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+# ❌ Bad — Mutable Docker tag
+- uses: docker://example/action:latest
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# Agent Instructions
+
+This file is the canonical repository guidance shared by GitHub Copilot, Codex,
+and Claude Code.
+
+## Scoped instructions
+
+- Before editing files under `.github/workflows/`, read and follow
+  `.github/workflows/AGENTS.md`.
+
+## Commit messages
+
+- Write in **English**
+- Follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`
+  - Example: `feat(starship): add SSH indicator to prompt`
+  - Types: `feat`, `fix`, `docs`, `refactor`, `chore`
+
+## Documentation structure
+
+Under `docs/`, place GitHub Flavored Markdown documentation built with Docusaurus:
+
+- `docs/guides/` — user guides (setup and usage)
+- `docs/reference/` — reference (tool list, configuration specs)
+- `docs/development/` — contributor information (structure, style guide)
+- `docs/development/99-adr/` — Architecture Decision Records
+
+### Documentation mapping table
+
+| Topic              | Path                                        | Audience     |
+| ------------------ | ------------------------------------------- | ------------ |
+| Quick start        | `docs/guides/01-quick-start.md`             | Users        |
+| Installation       | `docs/guides/02-installation.md`            | Users        |
+| Link management    | `docs/guides/03-managing-links.md`          | Users        |
+| Git identity       | `docs/guides/04-git-identity.md`            | Users        |
+| How to use skills  | `docs/guides/06-skills.md`                  | Users        |
+| Ghostty            | `docs/reference/ghostty.md`                 | Users        |
+| Git                | `docs/reference/git.md`                     | Users        |
+| mise               | `docs/reference/mise.md`                    | Users        |
+| Neovim             | `docs/reference/nvim.md`                    | Users        |
+| RTK                | `docs/reference/rtk.md`                     | Users        |
+| Sheldon            | `docs/reference/sheldon.md`                 | Users        |
+| Starship           | `docs/reference/starship.md`                | Users        |
+| tmux               | `docs/reference/tmux.md`                    | Users        |
+| Zsh                | `docs/reference/zsh/README.md`              | Users        |
+| Zsh plugins        | `docs/reference/zsh/plugins.md`             | Users        |
+| install_map.json   | `docs/reference/install-map.md`             | Users        |
+| gh-infra           | `docs/reference/gh-infra.md`                | Users        |
+| gh-qwt             | `docs/reference/gh-qwt.md`                  | Users        |
+| Scripts            | `docs/reference/scripts.md`                 | Users        |
+| Tools (Brewfile)   | `docs/reference/tools.md`                   | Users        |
+| Agent Skills       | `docs/reference/skills.md`                  | Users        |
+| Project structure  | `docs/development/01-project-structure.md`  | Contributors |
+| Docs style         | `docs/development/02-docs-style.md`         | Contributors |
+| ADR index          | `docs/development/99-adr/README.md`          | Contributors |
+| Skills development | `docs/development/03-skills-development.md` | Contributors |
+| Testing            | `docs/development/04-testing.md`            | Contributors |
+
+Style reference to read before editing:
+
+- `docs/development/02-docs-style.md` — documentation writing style guide
+
+## Required workflow
+
+1. Before editing code, always read the related documents under `docs/` (at minimum, the relevant section `README` and related pages).
+2. Before editing documentation, always read `docs/development/02-docs-style.md` to understand the documentation policy and conventions.
+3. When changing code, scripts, or configuration, always update `docs/` in the same change. For the change checklist and scope mapping, refer to the "Documentation Strategy" section of `docs/development/02-docs-style.md`.
+4. After making changes, always verify documentation accuracy, link integrity, and coverage against the current implementation.
+5. If the current document structure is hard to understand, reorganize it as needed.
+6. Always keep documentation aligned with the current implementation. Do not defer updates to a later commit.
+7. If there are multiple options for architecture or technical choices, always record them in `docs/development/99-adr/`.
+
+## Docusaurus conventions
+
+- Add a numeric prefix in the `01-` format to filenames for sidebar ordering
+- Do not add numeric prefixes to section directories (`guides/`, `reference/`, `development/`)
+- Use each directory's `README.md` as the index page
+- Write links as relative paths with the `.md` extension
+- Start each page with a `# h1` title, followed by an explanatory paragraph
+
+## Required quality standards
+
+- Documentation must always state **what changed**, **why it changed**, and **how to operate it**
+- Make examples and commands ready to copy and use as-is
+- Avoid outdated guidance and duplicated guidance
+- **Never copy source code or configuration into documentation.** Reproducing real source or config files causes double maintenance and stale docs. Describe the behavior and link to the source file (for example, `dotfiles/zshrc`) instead. Only examples or sample snippets that are not maintained elsewhere belong in docs. See the "Source Code in Documentation" section of `docs/development/02-docs-style.md`
+- Include clear reasons in records of decisions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -71,6 +71,13 @@ Uses the same color scheme across the terminal, editor, and prompt.
 Build a fast and reproducible environment with mise, Sheldon, Starship, and Neovim.
 
 </Feature>
+<Feature>
+
+🤝 **Shared agent workflows**
+
+Use the same Agent Skills and instructions with GitHub Copilot, Codex, and Claude Code.
+
+</Feature>
 </FeatureGrid>
 
 ## Documentation

--- a/docs/development/01-project-structure.md
+++ b/docs/development/01-project-structure.md
@@ -6,6 +6,8 @@ This page organizes the roles of the repository's main directories and files.
 
 ```text
 .
+├── AGENTS.md              # Canonical repository instructions
+├── CLAUDE.md              # Claude Code adapter that imports AGENTS.md
 ├── install.sh              # Main setup script
 ├── install_map.json        # Symbolic link mapping table
 ├── Brewfile                # Homebrew package definitions
@@ -18,8 +20,10 @@ This page organizes the roles of the repository's main directories and files.
 │   ├── nvim/               # -> ~/.config/nvim (LazyVim)
 │   ├── sheldon/            # -> ~/.config/sheldon
 │   ├── starship.toml       # -> ~/.config/starship.toml
-│   ├── skills/             # -> ~/.copilot/skills (Copilot skills)
-│   └── copilot-instructions.md # -> ~/.copilot/copilot-instructions.md
+│   ├── skills/             # Canonical Agent Skills; linked per skill
+│   ├── agent-instructions.md # Canonical personal agent instructions
+│   ├── copilot-instructions.md # Legacy adapter for pre-migration links
+│   └── copilot-hooks/      # Vendor-specific Copilot hooks
 ├── scripts/                # Setup scripts
 │   ├── 000-codespace.sh
 │   ├── 001-homebrew.sh
@@ -35,13 +39,17 @@ This page organizes the roles of the repository's main directories and files.
 ├── .docusaurus/            # Docusaurus site build
 ├── .github/
 │   ├── instructions/
-│   │   └── actions.instructions.md # GitHub Actions authoring guidance
-│   ├── copilot-instructions.md
+│   │   └── actions.instructions.md # Copilot adapter for workflow guidance
+│   ├── copilot-instructions.md # Copilot adapter for root AGENTS.md
 │   ├── dependabot.yml      # Dependency update settings for bun / GitHub Actions
 │   ├── settings.yml        # Declarative repository settings managed by gh-infra
 │   └── workflows/
+│       ├── AGENTS.md       # Canonical GitHub Actions authoring guidance
 │       ├── ci.yml          # Lint, bats tests, and a docs build check
 │       └── docs.yml        # Documentation deploy (main only)
+├── .claude/
+│   └── rules/
+│       └── github-actions.md # Claude adapter for workflow guidance
 ├── mise.toml               # Repository-local mise settings
 ├── package.json            # Scripts for building the documentation
 ├── .gitignore              # Definitions for untracked generated and local files
@@ -53,14 +61,20 @@ This page organizes the roles of the repository's main directories and files.
 
 | Path               | Role                                                                   | When to change it                                     |
 | ------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------- |
+| `AGENTS.md`        | Canonical repository instructions for coding agents                    | When changing repository-wide agent guidance          |
+| `CLAUDE.md`, `.github/copilot-instructions.md` | Thin product adapters for `AGENTS.md` | When an adapter mechanism changes, not for normal guidance edits |
 | `install.sh`       | Entry point for setup. Orchestrates link creation and script execution | When changing link handling or script execution logic |
-| `install_map.json` | Mapping table for symbolic links                                       | When adding or changing link targets                  |
+| `install_map.json` | Mapping table for ordinary links and Agent Skills targets              | When adding or changing link targets                  |
 | `Brewfile`         | List of packages managed by Homebrew                                   | When adding or removing tools                         |
-| `dotfiles/`        | Configuration files that are symlinked                                 | When changing the settings for each tool              |
+| `dotfiles/`        | Canonical personal configuration and agent files                       | When changing the settings for each tool              |
+| `dotfiles/skills/` | Canonical Agent Skills shared across supported agents                  | When adding or changing a skill                       |
+| `dotfiles/copilot-instructions.md` | Compatibility adapter for older personal Copilot links       | Only when changing or removing the migration adapter  |
+| `dotfiles/copilot-hooks/` | GitHub Copilot-specific hook configuration                    | When changing the Copilot hook; do not treat it as shared agent configuration |
 | `scripts/`         | Setup scripts                                                          | When changing tool installation procedures            |
 | `tests/`           | bats-core test suite                                                   | When adding logic worth testing, or changing tested behavior |
 | `.devcontainer/`   | Container definitions for GitHub Codespaces                            | When changing the Codespaces environment              |
-| `.github/instructions/` | Scoped instructions for GitHub Actions workflow authoring           | When changing workflow authoring or action pinning guidance |
+| `.github/workflows/AGENTS.md` | Canonical GitHub Actions authoring guidance                  | When changing workflow authoring or action pinning guidance |
+| `.github/instructions/`, `.claude/rules/` | Product adapters for path-scoped guidance       | When an adapter mechanism changes                     |
 | `.gitignore`       | Exclusion settings for files not tracked by Git                        | When adding generated files such as `node_modules/`   |
 
 ## Which Files Should Be Changed Together
@@ -78,6 +92,22 @@ This page organizes the roles of the repository's main directories and files.
 1. `dotfiles/zsh/<name>.zsh` — Create the plugin (`.zshrc` does not need editing; it is sourced automatically)
 2. `docs/reference/zsh/plugins.md` — Update the list
 3. If the plugin has logic that doesn't depend on Homebrew, network access, or fzf/interactive input, consider adding a `tests/<name>.bats` test (see [Testing](./04-testing.md))
+
+### When adding an Agent Skill
+
+1. `dotfiles/skills/<name>/SKILL.md` — Add the canonical, product-neutral skill
+2. `docs/reference/skills.md` — Update the skill list or shared behavior reference
+3. `docs/guides/06-skills.md` — Update user-facing guidance when invocation or prerequisites change
+4. `docs/development/03-skills-development.md` — Update authoring guidance when the skill format or installation behavior changes
+
+The existing `skill_targets` entry distributes new skill directories. Do not
+add a full-directory `links` entry for a product-specific skill root.
+
+### When changing agent instructions
+
+Edit the closest canonical `AGENTS.md` for repository or path-scoped rules, or
+`dotfiles/agent-instructions.md` for personal rules. Keep product adapters
+thin; do not copy the canonical instructions into them.
 
 ### When changing CI or tests
 

--- a/docs/development/03-skills-development.md
+++ b/docs/development/03-skills-development.md
@@ -1,6 +1,7 @@
 # Skill Development
 
-This is a guide for creating or modifying Copilot CLI custom skills.
+This is a guide for creating or modifying custom Agent Skills that work with
+GitHub Copilot, Codex, and Claude Code.
 
 ## Create a New Skill
 
@@ -46,11 +47,9 @@ What the user sees when the skill completes.
 
 ### 3. Verify it works
 
-If the symbolic link is already set up, the skill is available as soon as you create it:
-
-```bash
-copilot -p "/skill-name"
-```
+Run `bash install.sh` to create the per-skill links, then explicitly invoke the
+skill in each agent you support: `/skill-name` in GitHub Copilot,
+`$skill-name` in Codex, and `/skill-name` in Claude Code.
 
 If you see a loading error, check whether the `name` and `description` in the frontmatter are correct.
 
@@ -63,6 +62,20 @@ If you see a loading error, check whether the `name` and `description` in the fr
 | State constraints clearly | Prevents infinite loops and destructive operations          |
 | Define the output         | Clarifies what the user can expect                          |
 
+## Portability Rules
+
+- Put trigger conditions in the frontmatter `description` instead of relying
+  on one product's command syntax.
+- Refer to another skill by name, for example “use the `pr-fix` skill”. Do not
+  encode `/pr-fix`, `$pr-fix`, or another host-specific invocation in the
+  canonical procedure.
+- Describe optional helpers by capability. If a host-specific review subagent
+  is unavailable, define a provider-independent fallback review pass.
+- Keep hooks, manifests, permission schemas, and product settings outside the
+  shared skill. Those files stay in vendor-specific directories.
+- Test explicit invocation in all supported agents when a change affects
+  discovery, inputs, or cross-skill delegation.
+
 ## Branch-workspace skills
 
 When a PR skill needs a branch workspace, use the repository's
@@ -71,6 +84,16 @@ the invoking checkout.
 
 - Resolve the target worktree with `gh qwt path` and name that path explicitly
   in subsequent Git commands.
+- Require raw `gh qwt list --exact --full-path` output to contain each
+  calculated worktree path byte-for-byte before reuse and after the `get` or
+  `add` that creates it. For a new feature branch, verify the default worktree
+  after bootstrap `get` and the feature target after `add`. Treat an occupied
+  unregistered path as a collision.
+- Treat the GitHub host as part of repository identity even though qwt omits it
+  from the path. Resolve the canonical remote identity, compare it with the
+  existing bare `origin` before any operation, pass `--host` when provisioning,
+  and verify the new repository before use. Stop on a collision instead of
+  changing `origin`.
 - Provision a missing repository with `gh qwt get`; provision a missing branch
   worktree with `gh qwt add`. Refresh `origin` in an existing qwt repository
   before `add`, because `add` uses cached remote refs. Before editing a reused
@@ -89,22 +112,25 @@ that broader behavior is explicitly required.
 
 ## File Placement
 
-```
-dotfiles/skills/
-└── <skill-name>/
-    └── SKILL.md       # Required: skill definition file
-```
-
 - 1 skill = 1 directory
 - Directory name = skill name (kebab-case)
+- Place the required definition at `dotfiles/skills/<skill-name>/SKILL.md`
 - You may also place additional files (such as templates) in the same directory
 
 ## Installation
 
-Because `"skills": "~/.copilot/skills"` is already registered in `install_map.json`, running `install.sh` creates the symbolic link. If the link already exists, the new skill is recognized without any additional action.
+`install_map.json` declares `~/.agents/skills/` and `~/.claude/skills/` as
+`skill_targets`. Running `install.sh` links the new skill directory into each
+target without replacing the target itself. GitHub Copilot and Codex discover
+the first target; Claude Code discovers the second.
+
+GitHub Copilot checks `~/.copilot/skills/` before `~/.agents/skills/` for a
+duplicate name. When testing a shared skill, remove or rename any same-named
+entry in that higher-priority personal root so the canonical link is the one
+being exercised.
 
 ## Testing Tips
 
-- After writing a skill, actually invoke it with `copilot -p "/skill-name"` to confirm it works
+- After writing a skill, explicitly invoke it in GitHub Copilot, Codex, and Claude Code to confirm discovery and behavior
 - If the agent does not follow the steps as intended, make the step descriptions more specific
 - Stability improves if you define failure behavior in the `Constraints` section, such as retry counts and stop conditions

--- a/docs/development/04-testing.md
+++ b/docs/development/04-testing.md
@@ -62,6 +62,9 @@ them.
 
 Current coverage:
 
+- `tests/agent_configuration.bats` — the root and GitHub Actions canonical
+  `AGENTS.md` files, their Copilot and Claude adapters, and the legacy personal
+  Copilot adapter's forward reference to canonical personal instructions.
 - `tests/starship_qwt_worktree.bats` — `dotfiles/zsh/starship-qwt-worktree.sh`
   behavior: the `owner/repo/branch` label at a worktree root, the appended
   subdirectory path from inside a worktree, slash-containing branch names, and
@@ -69,11 +72,19 @@ Current coverage:
 - `tests/install_symlinks.bats` — `install.sh`'s symlink-creation logic,
   exercised against a copy of the real script in an isolated sandbox (fixture
   `install_map.json` and `dotfiles/`, empty `scripts/` so no real installs
-  run): link creation, idempotent re-runs, and converting a symlinked parent
-  directory into a real one while migrating its existing contents.
-- `tests/install_map.bats` — every `install_map.json` entry resolves to a real
-  path under `dotfiles/`, and every destination looks like an absolute or
-  `~`-rooted path.
+  run): single- and multi-destination link creation, per-skill links into every
+  `skill_targets` root, idempotent re-runs, preservation of unrelated skills,
+  resolving relative parent links, converting valid symlinked parents while
+  migrating their contents, and preserving dangling or non-directory parent
+  links on failure. Failure cases cover invalid JSON, invalid skill-target
+  schema, and path-resolution helper errors before cleanup. Migration tests
+  also verify that the legacy Copilot skill link remains available until every
+  replacement link succeeds and throughout those failures, and that an empty
+  skill-target list does not remove the only legacy discovery path.
+- `tests/install_map.bats` — every `links` source resolves to a real path under
+  `dotfiles/`, destination values have the supported string or string-array
+  shape, the shared personal instruction destinations are present, and skill
+  targets include the common and Claude discovery roots using valid paths.
 
 ### Adding a new test
 

--- a/docs/development/99-adr/0010-pr-skills-gh-qwt.md
+++ b/docs/development/99-adr/0010-pr-skills-gh-qwt.md
@@ -30,6 +30,21 @@ branch-workspace mechanism.
   obtain its absolute path with `gh qwt path`.
 - Run repository commands against the resolved path, using `git -C <path>`
   where a Git command needs an explicit working directory.
+- Do not infer worktree registration from a calculated path or from a Git
+  checkout found there. Require raw `gh qwt list --exact --full-path` output to
+  contain the calculated worktree path byte-for-byte before reuse and after
+  the `get` or `add` that creates it. For a new feature branch, verify the
+  default worktree after its bootstrap `get`, then verify the feature target
+  after `add`. Treat an occupied unregistered target, or an occupied repository
+  path without its qwt `.bare` database, as a collision.
+- Treat canonical `<host>/<owner>/<repo>` identity as part of every qwt
+  repository key even though the on-disk qwt path contains only
+  `<owner>/<repo>`. Resolve and compare the expanded bare `origin` before any
+  existing repository is listed, fetched, reused, pushed, or removed. Pass the
+  verified host explicitly to `gh qwt get`, verify the newly created bare
+  repository, and stop on a host collision instead of rewriting `origin`.
+  Repositories with the same owner/name on different hosts require separate
+  qwt roots.
 - Do not run `git switch`, `git checkout`, or a normal-clone branch-switching
   fallback in these skills. Do not fall back to `git worktree`.
 - When `pr-create` starts with uncommitted changes on the default branch,
@@ -85,8 +100,10 @@ the skills can provision a worktree deterministically with `gh-qwt`.
 - A first use from a repository without a qwt checkout may clone the
   repository into the qwt root.
 - A qwt path conflict, unavailable `gh qwt`, missing or deleted fork, dirty
-  worktree at merge time, or unsafe default-branch migration stops the skill
-  with an actionable error. It must not silently fall back to a checkout.
+  worktree at merge time, missing exact worktree registration,
+  host/repository identity mismatch, or unsafe default-branch migration stops
+  the skill with an actionable error. It must not silently fall back to a
+  checkout or repoint the existing remote.
 - Feature worktrees remain after `pr-fix` for subsequent iterations. A
   successful `pr-merge` removes the corresponding clean worktree and local
   branch, then attempts lease-protected head-remote cleanup. A remote cleanup

--- a/docs/development/99-adr/0013-cross-agent-skills-and-instructions.md
+++ b/docs/development/99-adr/0013-cross-agent-skills-and-instructions.md
@@ -1,0 +1,104 @@
+# ADR 0013: Share Agent Skills and instructions across coding agents
+
+Use product-neutral canonical files with thin adapters so GitHub Copilot,
+Codex, and Claude Code follow the same skills and instructions.
+
+## Status
+
+Accepted
+
+## Context
+
+The repository originally installed its skills and personal instructions only
+into GitHub Copilot paths. The skill procedures themselves use the portable
+Agent Skills `SKILL.md` format, but Codex and Claude Code discover skills from
+different directories. Each agent also has different conventions for personal,
+repository, and path-scoped instructions.
+
+Maintaining independent copies would allow safety rules and PR workflows to
+drift. Linking an entire skill root is also unsafe: an agent may keep built-in
+or independently installed skills in that directory, and replacing the root
+would hide or remove them. Hooks, manifests, permissions, and similar
+integrations cannot be normalized in the same way because their schemas and
+execution models are product-specific.
+
+## Decision
+
+Adopt a canonical-plus-adapter architecture:
+
+- `dotfiles/skills/` is the only maintained source for shared Agent Skills.
+  `install.sh` creates a link for each individual skill under
+  `~/.agents/skills/` for GitHub Copilot and Codex, and under
+  `~/.claude/skills/` for Claude Code. Missing destination roots are created as
+  real directories, and an existing root is never replaced wholesale.
+- `dotfiles/agent-instructions.md` is the only maintained source for personal
+  instructions. It is linked to `~/.copilot/copilot-instructions.md`,
+  `~/.codex/AGENTS.md`, and `~/.claude/CLAUDE.md`.
+- The former `dotfiles/copilot-instructions.md` source remains as a thin
+  migration adapter so an existing Copilot link is not left dangling between
+  pulling the repository and rerunning the installer. New installs do not
+  target that adapter.
+- Root `AGENTS.md` is the canonical repository instruction file. Root
+  `CLAUDE.md` and `.github/copilot-instructions.md` are thin adapters that
+  import or point to it instead of duplicating its rules.
+- `.github/workflows/AGENTS.md` is the canonical path-scoped instruction file
+  for GitHub Actions workflows. `.github/instructions/actions.instructions.md`
+  and `.claude/rules/github-actions.md` are thin Copilot and Claude adapters.
+- `install_map.json` accepts either a string or an array of strings for each
+  `links` value. A separate top-level `skill_targets` array declares skill
+  discovery roots, and the installer expands it into per-skill links.
+- Shared skills and instructions use product-neutral capability language.
+  Product-specific hooks, manifests, permission settings, and integrations
+  remain in vendor-specific files.
+
+Canonical files hold policy and procedure. Adapters contain only the minimum
+syntax required to make a product load the nearest canonical file.
+
+## Alternatives Considered
+
+### Keep GitHub Copilot as the source and add product-specific copies
+
+This is straightforward initially, but every policy or workflow change would
+need to be applied consistently in three places. Silent drift is especially
+risky for worktree safety and PR automation, so this was not adopted.
+
+### Link the complete canonical skills directory into every product
+
+This would make installation simple, but it would replace each product's skill
+root. Built-in, system, or separately installed skills could be hidden or
+removed, so only per-skill links are created.
+
+### Generate every adapter from canonical files
+
+Generation can support products that cannot import another file, but it adds a
+build step and generated-file synchronization checks. The current products can
+use small checked-in adapters, so generation is not needed now.
+
+### Force hooks and manifests into one common format
+
+The products do not share compatible schemas or lifecycle semantics for these
+features. A common wrapper would obscure product behavior without removing the
+need for vendor-specific configuration, so these files remain separate.
+
+## Consequences
+
+- Skill procedures, personal guidance, repository rules, and workflow-specific
+  rules each have one clear source of truth.
+- GitHub Copilot gives a same-named skill under `~/.copilot/skills/` priority
+  over the shared `~/.agents/skills/` copy. Because independently managed
+  Copilot content is preserved, users must remove or rename a conflicting
+  entry when they want the canonical shared skill.
+- Installing one canonical personal file to multiple paths requires
+  string-array values in `links`.
+- Installing skills requires dedicated `skill_targets` processing and tests
+  that verify unrelated destination entries are preserved.
+- Skill authors must avoid product-specific invocation syntax and provide
+  capability-based fallbacks when an optional helper is unavailable.
+- Thin adapters must be kept valid for their host products, but ordinary rule
+  changes are made only in the canonical file.
+- Existing Copilot personal links continue through the compatibility adapter
+  until the installer replaces them with a direct canonical link.
+- Vendor-specific hooks and manifests still require separate maintenance and
+  testing.
+- A shared skill change should be exercised in GitHub Copilot, Codex, and
+  Claude Code when it affects discovery or host-dependent behavior.

--- a/docs/development/99-adr/README.md
+++ b/docs/development/99-adr/README.md
@@ -22,6 +22,7 @@ An ADR (Architecture Decision Record) is a document for recording important tech
 | [0010](./0010-pr-skills-gh-qwt.md)        | Use gh-qwt worktrees for Pull Request skills           | Accepted   |
 | [0011](./0011-ci-and-shell-testing.md)    | Add a CI workflow with bats-core tests and mise-provisioned lint tools | Accepted |
 | [0012](./0012-github-actions-sha-pinning.md) | Require immutable SHA pins for GitHub Actions      | Accepted   |
+| [0013](./0013-cross-agent-skills-and-instructions.md) | Share Agent Skills and instructions across coding agents | Accepted |
 
 ## How to Write a New ADR
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -10,7 +10,7 @@ This is the developer documentation for changing and extending the dotfiles repo
 
 - [Project Structure](./01-project-structure.md) — Directory structure and the role of each file
 - [Documentation Style](./02-docs-style.md) — Markdown writing conventions
-- [Skills Development](./03-skills-development.md) — How to author and vendor Copilot CLI skills
+- [Skills Development](./03-skills-development.md) — How to author and vendor Agent Skills shared across coding agents
 - [Testing](./04-testing.md) — CI jobs, the bats test suite, and how to run checks locally
 
 ## Design and Decisions

--- a/docs/guides/02-installation.md
+++ b/docs/guides/02-installation.md
@@ -22,7 +22,7 @@ bash install.sh
 
 ```mermaid
 graph TD
-    A[Read `install_map.json`] --> B[Create symbolic links]
+    A[Read `install_map.json`] --> B[Create ordinary and per-skill links]
     B --> C[Run `scripts/000-*.sh`]
     C --> D[Run `scripts/001-*.sh`<br/>Install Homebrew]
     D --> E[Run `scripts/002-*.sh`<br/>Brewfile packages]
@@ -32,12 +32,31 @@ graph TD
 
 ### 1. Create symbolic links
 
-It parses `install_map.json` with Python3 and, for each entry:
+The installer parses and type-checks all of `install_map.json` with Python3,
+and materializes the ordinary links and skill destinations before making any
+filesystem change. Invalid JSON or an unsupported value shape stops without
+changing existing links. For each ordinary `links` entry, it then creates
+every declared destination:
 
 1. Creates the destination parent directory with `mkdir -p` if it does not exist
-2. If the parent directory is a symbolic link, converts it to a real directory (to support migration from older environments)
+2. If the parent directory is a valid symbolic link to a directory, converts it to a real directory (to support migration from older environments); invalid targets stop without removing the link
 3. Removes any existing file or link
 4. Creates a symbolic link from `dotfiles/<source>` to `<target>`
+
+It then finds direct children of `dotfiles/skills/` that contain `SKILL.md`
+and links each one separately under every `skill_targets` directory. This
+preserves unrelated built-in or independently installed skills in those
+directories.
+
+After all replacement links succeed, it removes the former whole-directory
+`~/.copilot/skills` link only when that link resolves to this repository's
+canonical skills source. A failure while installing ordinary or per-skill
+links before that cleanup therefore leaves the legacy Copilot discovery path
+intact. Failures in the later setup scripts occur after link migration has
+finished and do not restore that legacy path.
+
+See [Adding and changing links](./03-managing-links.md) for procedures and
+[`install_map.json`](../reference/install-map.md) for the full format.
 
 ### 2. Run setup scripts
 
@@ -58,7 +77,10 @@ If global `user.email` and `~/.ssh/id_ed25519.pub` exist, it generates `~/.ssh/a
 
 ## Re-running
 
-`install.sh` is idempotent. No matter how many times you run it, it converges to the same state. Existing symbolic links are removed and then recreated.
+`install.sh` is idempotent for destinations still declared in the map. Existing
+managed links are removed and recreated safely. It intentionally preserves
+unrelated skill entries and does not remove destinations whose mapping or
+canonical skill was deleted; remove those stale links manually.
 
 ## Environment variables
 

--- a/docs/guides/03-managing-links.md
+++ b/docs/guides/03-managing-links.md
@@ -1,6 +1,7 @@
 # Adding and changing links
 
-This page explains how to manage symbolic link mappings by editing `install_map.json`.
+This page explains how to manage ordinary and Agent Skills symbolic links by
+editing `install_map.json`.
 
 ## `install_map.json` format
 
@@ -8,32 +9,38 @@ This page explains how to manage symbolic link mappings by editing `install_map.
 {
   "links": {
     "<source>": "<target>",
-    ...
-  }
+    "<shared-source>": ["<target-a>", "<target-b>"]
+  },
+  "skill_targets": ["<skill-root-a>", "<skill-root-b>"]
 }
 ```
 
-| Field      | Description                                                   |
-| ---------- | ------------------------------------------------------------- |
-| `<source>` | File or directory name inside the `dotfiles/` directory       |
-| `<target>` | Absolute destination path (`~` expands to the home directory) |
+| Field              | Description                                                                  |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `<source>`         | File or directory name inside the `dotfiles/` directory                      |
+| `<target>`         | One absolute destination path (`~` expands to the home directory)            |
+| `<shared-source>`  | A source that must be linked to more than one destination                    |
+| `skill_targets`    | Destination directories that receive one link per directory in `dotfiles/skills/` |
 
 ## Add a link
 
-### Example: manage Copilot skills
+### Example: share one configuration file
 
-1. Place the configuration files in `dotfiles/`:
+1. Place the canonical file in `dotfiles/`:
 
 ```bash
-cp -r ~/.copilot/skills dotfiles/skills
+cp ~/.example-agent/instructions.md dotfiles/agent-instructions.md
 ```
 
-2. Add an entry to `install_map.json`:
+2. Give its `links` entry an array of destinations:
 
 ```json
 {
   "links": {
-    "skills": "~/.copilot/skills"
+    "agent-instructions.md": [
+      "~/.example-agent-a/instructions.md",
+      "~/.example-agent-b/instructions.md"
+    ]
   }
 }
 ```
@@ -43,6 +50,33 @@ cp -r ~/.copilot/skills dotfiles/skills
 ```bash
 bash install.sh
 ```
+
+Each destination receives a symbolic link to the same canonical source file.
+
+### Add an Agent Skill
+
+Create one directory under `dotfiles/skills/` and place its `SKILL.md` there.
+The configured `skill_targets` already distribute every skill directory when
+`install.sh` runs, so adding a skill does not require another mapping entry.
+
+```bash
+mkdir -p dotfiles/skills/example-skill
+${EDITOR:-vi} dotfiles/skills/example-skill/SKILL.md
+```
+
+Add the required `name` and `description` frontmatter plus the operating
+procedure before installing it. See
+[Skill Development](../development/03-skills-development.md) for a complete
+sample structure. Then run:
+
+```bash
+bash install.sh
+```
+
+The installer creates `example-skill` links under both shared agent skill
+roots. It preserves the roots themselves and any unrelated installed skills.
+See [Using skills](./06-skills.md) for the destinations used by GitHub Copilot,
+Codex, and Claude Code.
 
 ### Example: add an application under `~/.config`
 
@@ -65,8 +99,41 @@ Remove the relevant entry from `install_map.json`, and remove the file in `dotfi
 > [!NOTE]
 > `install.sh` does not automatically remove links that are no longer in the entries. Remove existing symbolic links manually with `rm`.
 
+For a skill, remove its directory from `dotfiles/skills/` and remove the old
+per-skill links from each configured skill target. The installer does not
+delete links for skills that no longer exist in the canonical directory.
+
 ## About destination parent directories
 
 `install.sh` automatically creates the destination parent directory (`mkdir -p`). It is fine if `~/.config/` does not already exist.
 
 If `~/.config` was a symbolic link in an older environment, it converts it to a real directory first and then migrates the contents.
+Relative link targets are resolved from the directory containing the link. If
+the target is missing or is not a directory, installation stops without
+removing the original link.
+
+Missing skill target directories are created as real directories. The
+installer replaces an existing entry only at
+`<skill-target>/<skill-name>`; it never replaces the entire skill target. An
+existing target-root symlink is preserved, including a whole-directory alias
+to the canonical skills source.
+
+## Migration from the Copilot-only skill link
+
+Earlier versions linked all of `dotfiles/skills/` to `~/.copilot/skills`.
+After all replacement links are installed successfully, the installer removes
+that legacy path only when it is a symbolic link that resolves to this
+repository's canonical skills directory. It leaves real directories and links
+to any other source untouched. If ordinary or replacement-skill link
+installation fails before cleanup, the legacy link stays in place.
+
+This ordering and exact-target check prevent migration from deleting either
+the last working discovery path, canonical skills, or independently managed
+Copilot content.
+
+Older installations may also have
+`~/.copilot/copilot-instructions.md` linked to
+`dotfiles/copilot-instructions.md`. That source remains as a thin compatibility
+adapter, so pulling this change does not break the active Copilot instructions
+before installation. The next successful `install.sh` run relinks the
+destination directly to canonical `dotfiles/agent-instructions.md`.

--- a/docs/guides/05-concept.md
+++ b/docs/guides/05-concept.md
@@ -11,11 +11,24 @@ It eliminates manual setup steps and post-installation work as much as possible 
 ## Declarative configuration management
 
 - **Symbolic links** — Declare source → target in `install_map.json`
+- **Agent Skills** — Keep one canonical skill directory and distribute each skill to the supported discovery roots
 - **Packages** — Declare required tools in `Brewfile`
 - **Plugins** — Declare Zsh plugins in `plugins.toml` (sheldon)
 - **Runtimes** — Declare language versions in `config.toml` (mise)
 
 Everything about "what to install" is written in configuration files, and the scripts only "apply the configuration files."
+
+## One source of truth for coding agents
+
+GitHub Copilot, Codex, and Claude Code share canonical Agent Skills and
+instructions. Product-specific filenames are thin adapters, while hooks,
+manifests, and permission schemas remain vendor-specific because the products
+do not share those formats.
+
+This keeps operational and safety guidance consistent without replacing an
+agent's entire skill directory. See [Using skills](./06-skills.md) and
+[ADR 0013](../development/99-adr/0013-cross-agent-skills-and-instructions.md)
+for the layout and rationale.
 
 ## Use Tokyo Night Storm consistently as the theme
 

--- a/docs/guides/06-skills.md
+++ b/docs/guides/06-skills.md
@@ -1,13 +1,51 @@
 # Using skills
 
-This is a guide for getting started quickly with custom Copilot CLI skills.
+This is a guide for using the same custom Agent Skills with GitHub Copilot,
+Codex, and Claude Code.
 
 ## Prerequisites
 
 - dotfiles are already installed (`install.sh` has been run)
-- GitHub Copilot CLI is already installed
+- At least one supported coding agent is installed
 - The `gh-qwt` GitHub CLI extension is available (it is installed by the
   dotfiles setup)
+
+## Where skills are installed
+
+`dotfiles/skills/` is the canonical source. The installer creates one link per
+skill instead of linking the entire directory:
+
+| Agents | Discovery root |
+| ------ | -------------- |
+| GitHub Copilot and Codex | `~/.agents/skills/` |
+| Claude Code | `~/.claude/skills/` |
+
+Creating missing roots as real directories and never replacing an existing
+root preserves unrelated built-in and independently installed skills. See
+[`install_map.json`](../reference/install-map.md) for the mapping format.
+
+> [!WARNING]
+> GitHub Copilot gives `~/.copilot/skills/` higher priority than
+> `~/.agents/skills/` when duplicate skill names exist. The installer preserves
+> a real `~/.copilot/skills/` directory or a link to another source, so a stale
+> `pr-create`, `pr-fix`, or `pr-merge` entry there overrides the shared version.
+> Remove or rename that conflicting entry when you want Copilot to use the
+> canonical skill installed under `~/.agents/skills/`. See GitHub's
+> [skill location priority](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#skills-reference).
+
+## Invoke a skill
+
+Start an interactive session and use the syntax for that agent:
+
+| Agent | Explicit invocation |
+| ----- | ------------------- |
+| GitHub Copilot | `/pr-create` |
+| Codex | `$pr-create` |
+| Claude Code | `/pr-create` |
+
+Use the corresponding name for `pr-fix` or `pr-merge`. Natural-language
+requests can also trigger a skill through its frontmatter description, but an
+explicit invocation is the most predictable choice.
 
 ## Available skills
 
@@ -19,12 +57,15 @@ This is a guide for getting started quickly with custom Copilot CLI skills.
 
 ## How PR skills use worktrees
 
-The PR skills do not switch the branch of the checkout where you invoked
-Copilot. They create or reuse a [`gh-qwt`](../reference/gh-qwt.md) worktree
+The PR skills do not switch the branch of the checkout where you invoked the
+agent. They create or reuse a [`gh-qwt`](../reference/gh-qwt.md) worktree
 for the feature or PR head branch, then perform Git operations only in that
 path.
 
 - On a first use, the skill can provision the repository under your qwt root.
+- The skill verifies the full GitHub host and repository identity before using
+  a qwt path. Repositories with the same `owner/repo` on different GitHub hosts
+  need separate qwt roots because the on-disk path omits the host.
 - `pr-create` safely transfers staged, unstaged, and non-ignored untracked
   changes from a default-branch worktree into the new feature worktree.
 - If the default branch has local commits, the skill stops instead of resetting,
@@ -32,6 +73,9 @@ path.
 - A branch name that collides with another qwt path, such as `feat` and
   `feat/login`, stops with an error rather than falling back to a branch
   switch.
+- A directory at the calculated path is used only when qwt reports that exact
+  absolute path as a registered worktree; stale or unrelated occupied paths
+  stop as collisions.
 - `pr-fix` works in the PR head worktree, including a fork's repository when
   applicable. `pr-merge` removes the clean worktree after a successful merge.
 
@@ -42,37 +86,31 @@ path.
 
 ## Use `pr-create`
 
-With your changes staged:
+With the intended changes already committed or present as staged, unstaged,
+or non-ignored untracked files, explicitly invoke `pr-create` using the syntax
+for your agent.
 
-```bash
-copilot -p "/pr-create"
-```
-
-If you want to explain the reason for the change:
-
-```bash
-copilot -p "/pr-create Refactor authentication logic, related to #42"
-```
-
-In an interactive session, you can also start it with `/pr create` (described later).
+You can add context after the invocation, such as “Refactor authentication
+logic, related to #42”. A natural-language request to create a PR also selects
+this skill through the shared personal instructions.
 
 ### What happens
 
 1. Checks for a corresponding Task (Issue) and suggests creating one if it does not exist
-2. Reads the diff and comes up with a commit message
+2. Reads the committed and uncommitted state, confirms the intended scope, and
+   comes up with a commit message
 3. Creates or reuses an isolated qwt feature worktree and safely moves
    uncommitted changes there when needed
-4. Commits and pushes the feature branch from that worktree
+4. Stages the intended uncommitted paths, then commits and pushes the feature
+   branch from that worktree
 5. Creates a draft PR
 6. Sets you as the assignee
 
 ## Use `pr-fix`
 
-```bash
-copilot -p "/pr-fix PR #42"
-```
-
-In an interactive session, you can also start it with `/pr fix` (described later).
+Explicitly invoke `pr-fix` and include the PR number, for example `PR #42`.
+A natural-language request to fix or make a PR mergeable also selects this
+skill through the shared personal instructions.
 
 ### What happens
 
@@ -83,35 +121,26 @@ In an interactive session, you can also start it with `/pr fix` (described later
 5. Performs a local review before pushing
 6. Replies to each review comment with what was addressed and resolves the thread
 
-You can also specify a mode:
-
-```bash
-copilot -p "/pr-fix ci #42"        # CI failures only
-copilot -p "/pr-fix feedback #42"  # Review comments only
-copilot -p "/pr-fix conflicts #42" # Conflicts only
-```
+You can also specify `ci`, `feedback`, or `conflicts` before the PR number to
+limit the run to CI failures, review comments, or conflicts respectively.
 
 ## Use `pr-merge`
 
-```bash
-copilot -p "/pr-merge 42"
-```
-
-Multiple PRs can be given at once, separated by spaces; they are processed one at a time:
-
-```bash
-copilot -p "/pr-merge 42 43"
-```
-
-In an interactive session, you can also start it with `/pr merge` (described later).
+Explicitly invoke `pr-merge` followed by a PR number. Multiple PRs can be given
+at once, separated by spaces; they are processed one at a time. A
+natural-language request to merge a review-clean PR also selects this skill
+through the shared personal instructions.
 
 ### What happens
 
 For each PR number given:
 
 1. Runs `pr-fix` and requests a review from Copilot Code Review, repeating until there are no unresolved findings (up to 10 attempts)
-2. Takes the PR out of Draft and applies the `self approval` label
-3. Waits for the repository's existing self-approval automation to approve the PR (up to 3 minutes)
+2. Takes the PR out of Draft, reuses an existing valid approval, or applies the
+   `self approval` label once
+3. Waits for the repository's existing self-approval automation to approve the
+   PR (up to 3 minutes from that one request); the approval is retained across
+   CI or conflict retries while it remains valid
 4. Waits for CI to go green, going back to step 1 if a merge conflict or a CI failure shows up
 5. Squash merges the PR once everything is green, then removes its qwt
    worktree and branch workspace
@@ -121,34 +150,39 @@ If a PR cannot be brought to a mergeable state, it is skipped (with the reason r
 > [!IMPORTANT]
 > `pr-merge` waits for an existing automation that approves PRs labeled `self approval` — it does not create that automation. It also expects the `self approval` label to already exist in the repository.
 
-## Interactive session integration
+## Shared instructions
 
-`install.sh` creates a symbolic link from `dotfiles/copilot-instructions.md` to `~/.copilot/copilot-instructions.md`.
-This file contains the following instructions and is always loaded in interactive sessions:
+Personal instructions have one canonical source,
+`dotfiles/agent-instructions.md`. `install.sh` links it to the locations loaded
+by GitHub Copilot, Codex, and Claude Code:
 
-- For repository tasks other than the PR workflows, record the invoking checkout's repository-relative working directory and working state, identify an existing qwt repository by its `.bare` directory, and inspect the matching target before reuse.
-- Bypass RTK filtering for parsed or equality-checked safety probes while preserving their exit status, and recognize a registered target by an exact target-path line in raw `gh qwt list` output rather than requiring that query to return only one line.
-- Whenever the source and target differ, compare the recorded source commit with a tracking branch that belongs to the resolved repository, a matching remote branch, or the selected base, even when the source is dirty. Ahead or diverged source history requires an explicit publish, transfer-to-target, or omit decision; work does not continue in an ordinary source checkout.
-- If the source and target differ and either has uncommitted changes, migrate them deliberately with verification or stop to ask how to proceed instead of abandoning or mixing them. Provision a target only when it is missing, and specify the repository explicitly with `get` or `add --repo`.
-- Resolve the full GitHub `host/owner/repo` identity, verify an existing qwt repository's canonical `origin` before reuse, and pass the host explicitly when provisioning. This prevents the host-less qwt path layout from mixing repositories on different GitHub hosts.
-- Fetch and compare the target before work. Fast-forward only a clean target that is behind, stop on a dirty behind target, and require an explicit choice for ahead, diverged, or local-only target history. Treat a previously tracked branch whose remote disappeared as deleted rather than automatically recreating it as new. Continue from the existing target counterpart of the recorded source-relative directory only after its physical path is verified inside the target worktree.
-- When `/pr create` is invoked → use the `pr-create` skill
-- When `/pr fix` is invoked → use the `pr-fix` skill
-- When `/pr merge` is invoked → use the `pr-merge` skill
+- `~/.copilot/copilot-instructions.md`
+- `~/.codex/AGENTS.md`
+- `~/.claude/CLAUDE.md`
 
-The general worktree setup does not run before these PR mappings. Each PR skill selects its own target, and `pr-create` first records the state of the checkout where it was invoked so it can migrate dirty changes safely. As a result, even when you use the built-in `/pr` subcommand, it behaves according to the procedure defined in the skills.
+The file defines the general `gh-qwt` safety workflow and maps PR creation,
+fixing, and merging requests to the corresponding shared skills. The detailed
+procedures remain in the skills, so all three agents execute the same workflow
+instead of maintaining product-specific copies.
 
-> [!NOTE]
-> This integration works through Copilot instruction loading and is not a completely deterministic binding. If you want to ensure the skill is used, invoke it directly with `/pr-create`, `/pr-fix`, or `/pr-merge`.
+Repository instructions follow the same canonical-plus-adapter pattern. Root
+`AGENTS.md` is canonical; `.github/copilot-instructions.md` and `CLAUDE.md` are
+thin adapters for tools that require their own filename. GitHub Actions rules
+are scoped by canonical `.github/workflows/AGENTS.md`, with thin Copilot and
+Claude adapters at their product-specific paths.
 
-## Alias setup (recommended)
+Hooks, manifests, permissions, and other product-specific configuration do not
+share a schema. They remain under their vendor-specific directories and can
+refer to the shared instructions or skills where appropriate.
+
+## Copilot CLI aliases (optional)
 
 Add the following to `.zshrc` or `.bashrc`:
 
 ```bash
-alias pr-create='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-create skill $*"; }; f'
-alias pr-fix='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-fix skill $*"; }; f'
-alias pr-merge='f() { copilot --model ${COPILOT_MODEL:-claude-sonnet-4.6} -p "/pr-merge skill $*"; }; f'
+alias pr-create='f() { copilot -p "/pr-create skill $*"; }; f'
+alias pr-fix='f() { copilot -p "/pr-fix skill $*"; }; f'
+alias pr-merge='f() { copilot -p "/pr-merge skill $*"; }; f'
 ```
 
 Usage:

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,3 +16,4 @@ A collection of guides covering everything from setting up these dotfiles to eve
 - [Adding and changing links](./03-managing-links.md) — How to edit `install_map.json`
 - [Automatic Git ID switching](./04-git-identity.md) — Multi-account workflows
 - [Concept](./05-concept.md) — Design philosophy and policies
+- [Using skills](./06-skills.md) — Shared Agent Skills for GitHub Copilot, Codex, and Claude Code

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -24,6 +24,7 @@ a detailed reference for the dotfiles configuration files, tool list, and struct
 - [gh-infra](./gh-infra.md) — Declarative repository settings management with `.github/settings.yml`
 - [gh-qwt](./gh-qwt.md) — Managing GitHub repositories and git worktrees together with the gh-qwt GitHub CLI extension
 - [install_map.json](./install-map.md) — Specification for the symbolic link mapping table
+- [Agent Skills](./skills.md) — Shared skill format, installation destinations, and PR workflow behavior
 - [Script list](./scripts.md) — The role of each script under `scripts/`
 - [Tool list](./tools.md) — Tools managed in the Brewfile and their purposes
 

--- a/docs/reference/gh-qwt.md
+++ b/docs/reference/gh-qwt.md
@@ -62,7 +62,9 @@ the remote branch according to the repository workflow.
 The `gh-config-dir.zsh` plugin recognizes the `.bare/` directory and `.git`
 pointer created by gh-qwt. It sets `GH_CONFIG_DIR` to the repository-level
 `.gh/` directory, so every branch worktree of the same repository uses the
-same `gh` account and Copilot token.
+same `gh` account. The plugin also synchronizes `COPILOT_GITHUB_TOKEN` for
+GitHub Copilot CLI; Codex and Claude Code continue to use their own agent
+authentication while sharing the same `gh` session for GitHub operations.
 
 Authentication stored in older worktree-specific directories is not copied,
 because it can contain tokens for different accounts. In any existing worktree,
@@ -109,23 +111,31 @@ gh qwt path cli/cli/fix/parser
 | `gh qwt path [<owner>/<repo>[/<branch>]]` | Print an absolute path (root, repository directory, or worktree path) for `cd` |
 | `gh qwt prune` | Remove worktrees whose branch is gone from the remote, discovered from the current directory |
 
-## Interactive session integration
+## Agent session integration
 
-`dotfiles/copilot-instructions.md` is loaded as `~/.copilot/copilot-instructions.md` in every interactive Copilot CLI session (see [Using skills](../guides/06-skills.md)). For repository tasks other than the PR workflows below, it records the invoking checkout's repository-relative working directory, branch, working state, and commit before resolving the expected `owner/repo/branch` target. When the source and target differ, it fetches the remote for the resolved repository and compares the recorded source commit with a matching tracking branch, remote branch, or chosen creation base, even when the source is dirty. An unrelated tracking remote is not used. Publishing, deliberately transferring, or explicitly leaving out ahead or diverged source history requires a choice; work does not continue in an ordinary source checkout.
+The canonical personal instructions at `dotfiles/agent-instructions.md` are
+linked to the paths loaded by GitHub Copilot, Codex, and Claude Code (see
+[Using skills](../guides/06-skills.md)). They apply the same `gh-qwt` safety
+workflow to general repository tasks in all three agents.
 
-The repository is considered an existing qwt repository only when its `.bare` directory exists, because `gh qwt path` also calculates paths for repositories and worktrees that have not been created. The source identity includes the GitHub host. Before an existing qwt repository is reused, its `origin` is resolved to a canonical GitHub repository and must match the full `host/owner/repo` identity. A missing repository is provisioned with the resolved host and branch explicitly.
+At a high level, the workflow records the invoking checkout, verifies the full
+GitHub host and repository identity, checks both source and target state, and
+uses only an explicitly resolved qwt worktree. It stops for a decision instead
+of silently abandoning dirty changes or rewriting ahead, diverged, deleted, or
+otherwise ambiguous history. Machine-readable safety probes bypass RTK
+filtering so their raw output and exit status remain reliable.
 
-An existing target is reused only after its branch and working state are inspected. Machine-readable safety probes bypass RTK filtering and preserve the original exit status. Because an exact `gh qwt list` query can also match another repository's branch name, registration requires an exact target-path line in the raw output; unrelated returned lines are ignored. If the source and target are different and either contains uncommitted changes, the instructions prevent silently abandoning or mixing those changes: migration must be deliberate and verified, or the session stops to ask how to proceed. Only a missing target is provisioned, with the repository passed explicitly to `get` or `add --repo`.
-
-Before work begins, the target fetches `origin` and compares its commit with the remote branch, or with the selected default-branch base when the target branch has not been published. A clean target that is only behind is fast-forwarded, while a dirty behind target stops for direction. Ahead, diverged, or otherwise local-only target history requires an explicit choice instead of an automatic reset, rebase, push, or overwrite. A dormant local branch that previously tracked a now-missing remote branch is treated as a deletion, not as a new branch, and requires an explicit restore, publish, rename, or abandon decision. The recorded source-relative directory must have an existing counterpart that physically resolves inside the target worktree; missing directories and symlink escapes stop instead of falling back to the target root. Subsequent work runs from that verified counterpart.
-
-PR requests are delegated directly from the invoking checkout to the matching skill before this general setup runs. This lets `pr-create` capture staged, unstaged, and untracked source changes before it selects and prepares its target worktree.
+PR requests use the matching shared skill before the general setup. This lets
+`pr-create` capture staged, unstaged, and untracked source changes before it
+selects and prepares its target worktree. The canonical instruction file and
+the skill definitions under `dotfiles/skills/` remain the authoritative
+procedure; this page describes their integration without copying them.
 
 ## Pull Request skill integration
 
-The `pr-create`, `pr-fix`, and `pr-merge` Copilot skills use `gh-qwt` as their
-only branch-workspace mechanism. They do not change the branch of the
-checkout that started the skill.
+The shared `pr-create`, `pr-fix`, and `pr-merge` Agent Skills use `gh-qwt` as
+their only branch-workspace mechanism in GitHub Copilot, Codex, and Claude
+Code. They do not change the branch of the checkout that started the skill.
 
 | PR phase | qwt behavior |
 | --- | --- |
@@ -133,12 +143,31 @@ checkout that started the skill.
 | Fix | Resolve the PR head repository and branch, including a fork head, then create or reuse that branch's worktree. |
 | Merge | Keep the head worktree through final CI, then remove the clean worktree and local branch after GitHub confirms the squash merge. |
 
+Since qwt paths omit the GitHub host, every PR skill records the canonical
+remote URL and full lowercase `<host>/<owner>/<repo>` identity. Before any
+existing qwt repository is listed, fetched, reused, pushed, or removed, its
+bare `origin` must resolve to that same identity. New repositories are created
+with the verified `--host` and checked again before use. A host collision stops
+the workflow and requires a separate `QWT_ROOT`; the skills never repoint the
+existing `origin`.
+
+A calculated path is not sufficient evidence that a branch is a qwt worktree.
+Before reuse and after each `get` or `add`, the skills require the raw
+`gh qwt list --exact --full-path` output to contain the worktree created by
+that command byte-for-byte. A default-branch bootstrap is checked at the
+default path before the feature target is created and checked after `add`. An
+unregistered occupied path is reported as a collision and is never inspected,
+edited, pushed, or removed as the PR target. An occupied repository path
+without the qwt `.bare` database also stops before `get` instead of being
+initialized in place.
+
 Before `add` is used in an existing qwt repository, the skills fetch
 `origin --prune` from the repository root. `add` relies on cached remote refs,
 so this refresh prevents a newly pushed PR branch from being mistaken for a
-new branch. A missing remote PR branch is created with `get --branch`; a new
-feature branch requires a default-branch `get` followed by `add`. A reused PR
-worktree must be clean and either fast-forward to its remote head or stop on
+new branch. A missing local qwt repository for an existing remote PR branch is
+created with `get --branch`; a new feature branch requires a default-branch
+`get` followed by `add`. A reused PR worktree must be clean and either
+fast-forward to its remote head or stop on
 an ahead/diverged branch.
 
 When `pr-create` starts from a dirty default branch, it transfers staged,
@@ -155,6 +184,11 @@ worktree spec outside a qwt repository. It then deletes the head remote branch
 only when its current ref still matches the verified PR head SHA, using a
 lease-protected push. This supports fork PR cleanup without risking deletion
 of a branch that changed after the merge check.
+
+The self-approval request used by `pr-merge` is also persistent across its
+review/CI retry loop. The label is applied at most once, the three-minute
+deadline is measured from that one request, and an approval that remains valid
+is reused after a retry instead of requiring a newer review.
 
 > [!IMPORTANT]
 > PR skills never use `git switch`, `git checkout`, ordinary `git worktree`,

--- a/docs/reference/install-map.md
+++ b/docs/reference/install-map.md
@@ -1,6 +1,7 @@
 # install_map.json
 
-This is the specification for the symbolic link mapping file.
+This is the specification for the ordinary-link and Agent Skills destination
+mapping file.
 
 ## Location
 
@@ -11,8 +12,10 @@ This is the specification for the symbolic link mapping file.
 ```json
 {
   "links": {
-    "<source>": "<target>"
-  }
+    "<source>": "<target>",
+    "<shared-source>": ["<target-a>", "<target-b>"]
+  },
+  "skill_targets": ["<skill-root-a>", "<skill-root-b>"]
 }
 ```
 
@@ -22,39 +25,64 @@ This is the specification for the symbolic link mapping file.
 
 An object that defines symbolic link mappings.
 
-| Key        | Type   | Description                                                          |
-| ---------- | ------ | -------------------------------------------------------------------- |
-| `<source>` | string | Relative name of a file or directory under the `dotfiles/` directory |
-| `<target>` | string | Absolute destination path. `~` is expanded to the home directory     |
+| Key        | Type                 | Description                                                          |
+| ---------- | -------------------- | -------------------------------------------------------------------- |
+| `<source>` | string               | Relative name of a file or directory under the `dotfiles/` directory |
+| value      | string or string[]   | One destination or a list of destinations; `~` expands to the home directory |
 
-## Current entries
+Use an array when GitHub Copilot, Codex, Claude Code, or other tools must read
+the same canonical file from different product-specific paths. The current
+source-to-destination declarations live only in
+[`install_map.json`](https://github.com/daiksud/dotfiles/blob/main/install_map.json).
 
-| Source                    | Target                               | Contents                               |
-| ------------------------- | ------------------------------------ | -------------------------------------- |
-| `zshrc`                   | `~/.zshrc`                           | Zsh configuration file                 |
-| `zsh`                     | `~/.zsh`                             | Zsh custom plugin directory            |
-| `tmux.conf`               | `~/.tmux.conf`                       | tmux configuration                     |
-| `gitconfig`               | `~/.gitconfig`                       | Global Git configuration               |
-| `ghostty`                 | `~/.config/ghostty`                  | Ghostty terminal configuration         |
-| `mise`                    | `~/.config/mise`                     | mise tool version configuration        |
-| `nvim`                    | `~/.config/nvim`                     | Neovim configuration (LazyVim)         |
-| `sheldon`                 | `~/.config/sheldon`                  | sheldon plugin configuration           |
-| `starship.toml`           | `~/.config/starship.toml`            | Starship prompt configuration          |
-| `skills`                  | `~/.copilot/skills`                  | Copilot CLI custom skills              |
-| `copilot-instructions.md` | `~/.copilot/copilot-instructions.md` | Copilot CLI personal instructions file |
+### skill_targets
+
+An array of directories that receive the skills under `dotfiles/skills/`.
+Every direct child directory that contains `SKILL.md` is treated as one skill,
+and the installer links that child into each target using the same directory
+name.
+
+Missing targets are created as real directories, while an existing target root
+is not replaced. This per-skill layout preserves unrelated built-in or
+independently installed skills and avoids replacing a tool's entire skill root.
 
 ## Processing specification
 
 Behavior when `install.sh` processes `install_map.json`:
 
-1. Parse the file with Python3's `json` module
-2. Expand `~` to `$HOME`
-3. For each entry:
-   - If the destination's parent directory is a symbolic link, convert it to a real directory and migrate the contents
+1. Parse and type-check both `links` and `skill_targets` with Python3's `json`
+   module, materializing both normalized result sets before changing the
+   filesystem. A syntax or schema error exits without changing any link
+2. Expand `~` to `$HOME` in every link and skill destination
+3. Normalize each `links` value to one or more destinations
+4. For each ordinary link destination:
+   - If the destination's parent directory is a symbolic link, resolve relative targets from the link's directory, verify that the target is an existing directory, then convert the parent to a real directory and migrate the contents
+   - If that parent link is dangling or points to a non-directory, leave it intact and stop the installation
    - If the parent directory does not exist, create it with `mkdir -p`
    - If an existing file/link is present, remove it with `rm -rf`
    - Create a symbolic link from `dotfiles/<source>` to `<target>`
+5. For each direct child of `dotfiles/skills/` that contains `SKILL.md`, and
+   each `skill_targets` entry:
+   - Create a missing skill target as a real directory; preserve an existing
+     target root, including a symbolic-link root
+   - Replace only `<skill-target>/<skill-name>` if it already exists
+   - Link that path to the canonical skill directory
+
+When at least one skill target is configured, the installer checks the legacy
+`~/.copilot/skills` path after every ordinary link and replacement skill link
+succeeds. It removes that path only when it is a symbolic link that resolves
+to this repository's `dotfiles/skills/`; unrelated links and real directories
+are preserved. An empty `skill_targets` array provides no replacement
+discovery path, so it does not trigger cleanup. If link installation fails
+before cleanup, the legacy discovery path remains available. If a configured
+skill root is already a whole-directory link to the same canonical source, the
+installer also avoids deleting entries through that alias. Failure to resolve
+an existing or canonical path is treated as an installation error, not as
+evidence that two paths are equal.
 
 ## Constraints
 
 - Must be valid JSON (no trailing commas)
+- Every `links` value must be either a string or an array of strings
+- `skill_targets` must be an array of strings
+- Every source path is resolved relative to `dotfiles/`

--- a/docs/reference/rtk.md
+++ b/docs/reference/rtk.md
@@ -4,10 +4,10 @@ RTK is a CLI proxy that filters and compresses shell command output to reduce th
 
 ## Files
 
-| dotfiles                                                     | Link destination                     |
-| ------------------------------------------------------------ | ------------------------------------ |
-| `dotfiles/copilot-hooks/rtk-rewrite.json`                    | `~/.copilot/hooks/rtk-rewrite.json`  |
-| `dotfiles/copilot-instructions.md` (including the RTK block) | `~/.copilot/copilot-instructions.md` |
+| Canonical file | Link destination |
+| -------------- | ---------------- |
+| `dotfiles/copilot-hooks/rtk-rewrite.json` | `~/.copilot/hooks/rtk-rewrite.json` |
+| `dotfiles/agent-instructions.md` (including shared RTK guidance) | `~/.copilot/copilot-instructions.md`, `~/.codex/AGENTS.md`, and `~/.claude/CLAUDE.md` |
 
 ## Setup
 
@@ -23,8 +23,11 @@ brew install rtk
 rtk init --global --copilot
 ```
 
-Generates `~/.copilot/hooks/rtk-rewrite.json` and the RTK block in `~/.copilot/copilot-instructions.md`.
-In this repository, the hook file is managed as `dotfiles/copilot-hooks/rtk-rewrite.json`, and `install.sh` creates the symlink.
+This upstream command generates `~/.copilot/hooks/rtk-rewrite.json` and RTK
+instructions for GitHub Copilot. In this repository, the hook remains a
+Copilot-specific file at `dotfiles/copilot-hooks/rtk-rewrite.json`, while the
+portable RTK guidance is maintained once in `dotfiles/agent-instructions.md`.
+`install.sh` creates all corresponding links.
 
 ## Usage
 
@@ -38,7 +41,10 @@ rtk cargo test
 rtk docker ps
 ```
 
-When the hook is enabled, GitHub Copilot CLI automatically runs commands through `rtk` (no manual prefix needed).
+When the hook is enabled, GitHub Copilot CLI automatically runs commands
+through `rtk` (no manual prefix needed). Codex and Claude Code receive the
+shared usage and safety guidance, but this Copilot hook is not installed into
+their product-specific configuration.
 
 ### Machine-readable output
 
@@ -67,7 +73,10 @@ rtk init --show       # Check hook status
 rtk init --uninstall --global --copilot
 ```
 
-This removes only `~/.copilot/hooks/rtk-rewrite.json` and the RTK block in `copilot-instructions.md`. Other files are unaffected.
+This upstream command targets the Copilot hook and the instructions reached
+through `~/.copilot/copilot-instructions.md`. Because that instruction path is
+a link to the shared canonical file in this repository, review the resulting
+change before using it; removing shared RTK guidance affects all three agents.
 
 ## References
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,6 +1,7 @@
-# Copilot Skills
+# Agent Skills
 
-This is the specification reference for custom skills.
+This is the specification reference for custom skills shared by GitHub
+Copilot, Codex, and Claude Code.
 
 ## Skill list
 
@@ -12,22 +13,40 @@ This is the specification reference for custom skills.
 
 ## Installation destination
 
-When `install.sh` runs, `dotfiles/skills/` is symlinked to `~/.copilot/skills/`.
+`dotfiles/skills/` is the canonical source. When `install.sh` runs, each skill
+directory is linked separately into every configured discovery root.
 
-## Directory structure
+| Discovery root | Agents |
+| -------------- | ------ |
+| `~/.agents/skills/` | GitHub Copilot and Codex |
+| `~/.claude/skills/` | Claude Code |
 
-```
-dotfiles/skills/
-├── pr-create/
-│   └── SKILL.md
-├── pr-fix/
-│   └── SKILL.md
-└── pr-merge/
-    └── SKILL.md
-```
+Missing discovery roots are created as real directories, and existing roots
+are not replaced. Only their entries for `pr-create`, `pr-fix`, and `pr-merge`
+are managed as links, so unrelated built-in and independently installed skills
+remain untouched. The destinations are declared through `skill_targets`; see
+[`install_map.json`](./install-map.md).
+
+GitHub Copilot loads a same-named skill from `~/.copilot/skills/` before the
+shared copy under `~/.agents/skills/`. The installer removes
+`~/.copilot/skills` only when it is the former whole-directory link to this
+repository; it preserves real directories and links to other sources. Remove
+or rename a conflicting `pr-create`, `pr-fix`, or `pr-merge` entry in that
+higher-priority root to select the canonical shared version. See GitHub's
+[skill location priority](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#skills-reference).
+
+## Canonical source layout
+
+Each direct child of `dotfiles/skills/` that contains the required `SKILL.md`
+is one installable skill directory. See the
+[canonical skills directory](https://github.com/daiksud/dotfiles/tree/main/dotfiles/skills)
+for the current files instead of reproducing their contents here.
 
 > [!NOTE]
-> This repository has no vendored skills at the moment. A skill installed directly from an upstream repository with `gh skill install <repo> <skill>` (fetching the skill's directory, including `SKILL.md` and any accompanying files, verbatim) would carry extra frontmatter fields such as `compatibility`, `license`, and a `metadata` provenance block, and should be treated as synced content — re-run `gh skill install` to update it instead of hand-editing it to match the spec below.
+> This repository has no vendored skills at the moment. A skill installed
+> directly from an upstream repository should be treated as synced content:
+> use the same installation mechanism to update it instead of hand-editing the
+> vendored files to match this specification.
 
 ## `SKILL.md` format specification
 
@@ -98,12 +117,27 @@ name: Skill name
 | Field         | Type   | Description                                     |
 | ------------- | ------ | ----------------------------------------------- |
 | `name`        | string | Skill identifier. Must match the directory name |
-| `description` | string | Skill summary. Displayed in the CLI skill list  |
+| `description` | string | Skill summary used for discovery and agent selection |
 
 ### Language used in the body
 
-- Write the frontmatter `description` in **English** (used in the CLI skill list display)
+- Write the frontmatter `description` in **English** (used for discovery and selection)
 - Write the body in **English**
+
+### Portability requirements
+
+- Describe when the skill applies in `description`; do not depend on one
+  product's slash-command mapping for discovery.
+- Refer to another shared skill by its name, such as “use the `pr-fix` skill”.
+  Do not embed a product-specific invocation such as `/pr-fix` in the canonical
+  procedure.
+- Use capability-based language for optional helpers. For example, request a
+  dedicated review skill or review subagent when the host provides one, then
+  define a provider-independent fallback.
+- Keep hooks, manifests, permissions, and proprietary integration settings out
+  of shared skill files. Those remain in vendor-specific configuration.
+- Proper names for external services, such as Copilot Code Review, are allowed
+  when the workflow genuinely depends on that service.
 
 ### Section guidelines
 
@@ -121,12 +155,29 @@ The three PR skills use [`gh-qwt`](./gh-qwt.md) as their only
 branch-workspace mechanism. A branch is represented by its own worktree, not
 by changing the branch of the invoking checkout.
 
+- Because qwt paths omit the GitHub host, every skill resolves the remote
+  through GitHub and records its canonical URL plus the full lowercase
+  `<host>/<owner>/<repo>` identity. Before it lists, fetches, reuses, pushes,
+  or removes an existing qwt repository, that identity must match the bare
+  repository's expanded `origin` URL. A mismatch stops the skill instead of
+  rewriting `origin`; repositories with colliding paths require a separate
+  `QWT_ROOT`.
 - The skills resolve a target with `gh qwt path` and run repository commands
   against that absolute path.
+- Before reusing a calculated target, and after each `get` or `add`, the skills
+  require an unfiltered `gh qwt list --exact --full-path` result to contain the
+  worktree created by that command byte-for-byte. A default-branch bootstrap
+  `get` is checked at the default path before a feature-branch `add`; the
+  feature target is checked after `add`. An occupied path without exact qwt
+  registration is a collision, not a worktree. An occupied repository path
+  without its qwt `.bare` database is likewise a collision, not a missing
+  repository to initialize in place.
 - A missing qwt repository is provisioned with `gh qwt get`. A missing branch
   worktree in an existing qwt repository is created with `gh qwt add`.
   `get --branch` is used only for an existing remote branch; creating a new
   branch first requires `get` for the default branch, followed by `add`.
+  Provisioning passes the verified host explicitly with `get --host`, then
+  verifies the new bare repository before it is used.
 - Before `add` runs in an existing qwt repository, the skills refresh
   `origin --prune` from the qwt repository root so cached refs cannot turn a
   just-pushed branch into a mistakenly new branch.
@@ -155,7 +206,8 @@ the skill; it stops and asks for explicit direction instead.
 1. Check the corresponding Task (Issue) (if it cannot be inferred, ask the user to confirm; if there is none, encourage them to create one)
 2. Understand the source changes with `git diff` and the Issue description and comments
 3. Resolve or create the feature branch's qwt worktree, migrating uncommitted changes only through the verified preservation procedure
-4. Commit from the target worktree using the Conventional Commits format
+4. Stage the intended uncommitted paths and commit from the target worktree
+   using the Conventional Commits format
 5. Push the target branch
 6. Create the PR description (write a readable, visually clear body that fully leverages GFM features such as tables, alerts, Mermaid, and emoji), then create a draft PR with `gh pr create --draft`
 7. Set the invoking user as the Assignee
@@ -163,7 +215,8 @@ the skill; it stops and asks for explicit direction instead.
 
 ### Input
 
-- Staged files, or already committed diffs
+- Intended changes that are already committed, staged, unstaged, or present as
+  non-ignored untracked files
 - Optional: reason for the change, related Issue number
 
 ### Output
@@ -179,7 +232,7 @@ the skill; it stops and asks for explicit direction instead.
 3. If there are CI failures, analyze the logs and repeat fixes (up to 3 times)
 4. Retrieve all review comments and judge the validity of each one
 5. Fix valid comments and skip invalid ones; for comments the user replied "対応しない" (will not address) to, record in the PR body that they will not be addressed along with the reason
-6. Before committing and pushing, run a local review with the `code-review` sub-agent
+6. Before committing and pushing, perform an independent local review. Use a dedicated review skill or review subagent when the host provides one; otherwise make a separate review pass over the full diff
 7. After pushing, reply to each review comment with how it was addressed
 
 The PR API remains scoped to the base repository. Git changes and pushes occur
@@ -202,11 +255,17 @@ creating a substitute branch in the base repository.
 
 `pr-merge` runs a single retry loop (up to 10 iterations) per PR:
 
-1. Run `/pr-fix all <PR>`, request a review from Copilot Code Review (same GraphQL mutation as `pr-fix`), and wait for it to complete
+1. Use the `pr-fix` skill in `all` mode for the PR, request a review from Copilot Code Review (using the same GraphQL mutation), and wait for it to complete
 2. Count the unresolved findings left by Copilot Code Review (paginated `reviewThreads`, filtered to `copilot-pull-request-reviewer`); if any remain, go back to step 1
-3. Mark the PR ready for review (`gh pr ready`) and apply the `self approval` label
-4. Wait for the pre-existing self-approval automation to approve the PR (short 3-minute timeout, since a miss usually means the automation is not configured)
-5. Wait for CI to go green and re-check mergeability; a merge conflict or a CI failure sends control back to step 1, since `/pr-fix all` can fix both
+3. Mark the PR ready for review (`gh pr ready`). Reuse an existing valid
+   approval; otherwise apply the `self approval` label once and keep that
+   request timestamp across every retry
+4. Wait for the pre-existing self-approval automation to approve the PR
+   (short 3-minute timeout measured from the one persistent request, since a
+   miss usually means the automation is not configured). An approval that
+   remains valid is not discarded merely because CI or conflict handling
+   restarted the loop
+5. Wait for CI to go green and re-check mergeability; a merge conflict or a CI failure sends control back to step 1 because the `pr-fix` skill can fix both
 6. Once CI is green and there are no conflicts, verify that the qwt worktree
    is clean and still matches the PR head, squash merge with the checked head
    SHA, then remove the qwt worktree and local branch with `gh qwt remove

--- a/dotfiles/agent-instructions.md
+++ b/dotfiles/agent-instructions.md
@@ -1,0 +1,77 @@
+# Agent Personal Instructions
+
+## Pull Request skills
+
+If the user asks to create a Pull Request, always use the `pr-create` skill.
+If the user asks to fix, improve, or make a Pull Request mergeable, always use
+the `pr-fix` skill.
+If the user asks to merge a Pull Request once review is clean, always use the
+`pr-merge` skill.
+
+Invoke the matching skill through the current agent's skill mechanism directly
+from the checkout where the request was made. Do not create or select a
+worktree first: each skill owns its `gh-qwt` workflow, and `pr-create` must
+inspect and migrate the invoking checkout's dirty state.
+
+## Worktree usage
+
+For every other repository task, perform all work inside a `gh-qwt` worktree. Collect every probe whose output or exit status this workflow parses, compares, preserves for migration, or uses for a safety decision without RTK filtering, as specified in the raw-output exception below.
+
+1. Treat the checkout where the request was made as the source. Before changing directories or provisioning a worktree:
+   - Record its physically resolved absolute Git worktree root and current working directory. Require the working directory to equal the root or be its descendant using a path-component boundary, then derive and record that repository-relative working directory (`.` for the root). Do not derive it from raw `$PWD`, and reject an absolute or parent-traversing result.
+   - Record the current branch, `HEAD`, staged and unstaged diffs, non-ignored untracked-file list, and `git status --porcelain=v1 -z`.
+2. Resolve the selected source remote's expanded fetch URL through GitHub to obtain its canonical repository URL, lowercase host, canonical `<owner>/<repo>`, and default branch; do not infer `github.com` from an unqualified repository name. Also resolve the source branch and tracking ref and the intended `<branch>`, then calculate the qwt repository and target paths with `gh qwt path <owner>/<repo>` and `gh qwt path <owner>/<repo>/<branch>`.
+   - Treat the qwt repository as existing only when `<repository-path>/.bare` is a directory; `gh qwt path` also prints paths for missing repositories and worktrees.
+   - Because qwt paths omit the host, before listing, fetching, adding to, or reusing an existing qwt repository, read the expanded fetch URL for `origin` from its bare Git database, resolve that URL through GitHub, and require the resulting canonical URL and full `<host>/<owner>/<repo>` identity to equal the source repository. Stop if either identity cannot be verified or differs; do not fetch, rewrite `origin`, or reuse a repository belonging to another host. Use an explicitly selected separate qwt root or resolve the collision manually.
+3. Confirm whether the target is a registered worktree by requiring `gh qwt list <owner>/<repo>/<branch> --exact --full-path` to succeed without RTK filtering, then checking whether at least one stdout line equals the calculated target path byte-for-byte. Ignore other returned lines because `--exact` can also match another repository's branch name. Stop if the command fails; empty output or no exact target-path line means that the target is absent. If it exists, verify that its current branch equals the intended branch and stop on a mismatch, then record its staged, unstaged, untracked, and porcelain status before reuse.
+4. Compare the resolved source and target roots before doing any work:
+   - If the target is registered and they are the same worktree, continue there without discarding its current state. Treat an unregistered target as absent even if its calculated path matches the source textually.
+   - Otherwise, if the source or an existing target has uncommitted changes, do not silently leave the source or mix distinct states. Continue an existing dirty target only when the user explicitly identified its changes as the work to continue. Migrate source changes only when the user explicitly chose that outcome, after completing the committed-history check below, preserving staged, unstaged, and non-ignored untracked state and verifying the target before clearing the source. In all other cases, stop and ask how to proceed; never combine two dirty worktrees automatically.
+   - Proceed without migration only when the source is clean and the target is absent or clean.
+5. Whenever the source and target are different, fetch the remote that corresponds to the resolved `<host>/<owner>/<repo>` and compare committed history even when the source is dirty. Use a configured tracking ref only when it belongs to that full repository identity; otherwise use an existing matching `<remote>/<source-branch>`, or the fetched `<remote>/<default-branch>` as the creation base for an unpublished source branch. Compare that ref with the recorded source `HEAD`, for example with `git rev-list --left-right --count <source-ref>...<source-HEAD>`.
+   - Equal commits, or a source that is only behind the ref, have no local-only source history.
+   - A source that is ahead or diverged has local-only commits. Continue only when the user explicitly chose how to publish that exact history, deliberately transfer it to the target, or leave it out; otherwise stop and ask. Never keep working in the ordinary source, or push, rebase, reset, or omit those commits automatically.
+   - Stop if no trustworthy matching remote/base ref can be established.
+6. If the target is missing and the recorded state permits provisioning, use an explicit, host-aware repository. When the qwt repository is missing, always pass the already resolved branch as well as the host: use `gh qwt get --host <host> --branch <default-branch> <owner>/<repo>` for the default branch or replace that branch argument with an existing remote `<branch>`. For a new branch, initialize a missing repository with the explicit host and resolved default branch, reverify the created bare repository's identity as described above, then use `gh qwt add --repo <owner>/<repo> <branch> --from origin/<default-branch>`. When the verified repository already exists, refresh `origin --prune` and record whether `refs/heads/<branch>` plus any `branch.<branch>.remote` and merge configuration already exist before running `gh qwt add --repo <owner>/<repo> <branch>`. `add` reattaches an existing local branch before considering the remote and does not replace it with `--from`; add `--from` only when creating a genuinely new branch.
+7. Before doing any work in a reused or newly attached target, require its expected status, fetch `origin --prune`, and compare target `HEAD` with `origin/<branch>` when that remote branch exists, otherwise with the fetched `origin/<default-branch>` creation base.
+   - If the commits match, continue. If the remote/base is ahead with no target-only commits, fast-forward only when the target is clean by running `git -C <target> merge --ff-only <target-ref>`, then verify equality; if it is dirty, stop and ask instead.
+   - If the target is ahead, diverged, or has local-only history relative to the selected ref, continue only when the user explicitly selected how to use, publish, or reconcile that history. Never reset, rebase, force-push, or overwrite it automatically.
+   - If the remote target branch is missing but the local branch was configured to track it, treat this as a deleted-remote branch and stop for an explicit restore, publish, rename, or abandon decision even when target `HEAD` matches the default-branch base.
+   - Only a branch without prior upstream configuration may be treated automatically as new when target `HEAD` matches the selected creation base; otherwise its local-only history requires the explicit choice above. Stop if no trustworthy target ref can be established.
+8. Resolve the target path again and verify its registered worktree with the exact target-path line test above, then verify its branch, working state, and commit-history decision. Map the recorded source-relative working directory onto the target and require that counterpart to already exist as a directory. Physically resolve it and require the result to equal the resolved target root or be its descendant using a path-component boundary. Stop on a missing or non-directory counterpart, traversal, or symlink escape; do not create it or fall back to the target root. Change to the verified counterpart, confirm `pwd -P` still equals it, and run every subsequent repository command from that directory.
+
+## Comments on Issues / Pull Requests
+
+When posting a comment or reply on an Issue or Pull Request at the user's instruction, always prefix it with `:robot:`.
+
+<!-- rtk-instructions v2 -->
+# RTK — Token-Optimized CLI
+
+**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
+
+## Rule
+
+Always prefix shell commands with `rtk`:
+
+```bash
+# Instead of:              Use:
+git status                 rtk git status
+git log -10                rtk git log -10
+cargo test                 rtk cargo test
+docker ps                  rtk docker ps
+kubectl get pods           rtk kubectl get pods
+```
+
+## Meta commands (use directly)
+
+```bash
+rtk gain              # Token savings dashboard
+rtk gain --history    # Per-command savings history
+rtk discover          # Find missed rtk opportunities
+rtk proxy <cmd>       # Run raw (no filtering) but track usage
+```
+<!-- /rtk-instructions -->
+
+## Raw-output exception
+
+The RTK rule above does not apply when command output or exit status will be parsed, compared for equality, preserved for migration, or otherwise used for a safety decision. Run those commands with `RTK_DISABLED=1 <command>` or, for a simple command, through `rtk proxy <command>`; make decisions only from the raw output and original exit status. For the worktree workflow, this includes every recorded status, diff, ref, path, and list probe; never parse or compare filtered RTK output.

--- a/dotfiles/copilot-instructions.md
+++ b/dotfiles/copilot-instructions.md
@@ -1,72 +1,10 @@
-# Copilot Personal Instructions
+# Legacy Copilot Personal Instructions Adapter
 
-## Pull Request skills
+This file is retained only for existing
+`~/.copilot/copilot-instructions.md` links created by older versions of these
+dotfiles. Before doing any work, resolve this file's symlink target and read
+and follow the sibling `agent-instructions.md` in full. That sibling is the
+canonical personal guidance shared by GitHub Copilot, Codex, and Claude Code.
 
-If the user runs `/pr create` or asks to create a Pull Request, always use the `pr-create` skill.
-If the user runs `/pr fix` or asks to fix, improve, or make a Pull Request mergeable, always use the `pr-fix` skill.
-If the user runs `/pr merge` or asks to merge a Pull Request once review is clean, always use the `pr-merge` skill.
-
-Invoke the matching skill directly from the checkout where the request was made. Do not create or select a worktree first: each skill owns its `gh-qwt` workflow, and `pr-create` must inspect and migrate the invoking checkout's dirty state.
-
-## Worktree usage
-
-For every other repository task, perform all work inside a `gh-qwt` worktree. Collect every probe whose output or exit status this workflow parses, compares, preserves for migration, or uses for a safety decision without RTK filtering, as specified in the raw-output exception below.
-
-1. Treat the checkout where the request was made as the source. Before changing directories or provisioning a worktree:
-   - Record its physically resolved absolute Git worktree root and current working directory. Require the working directory to equal the root or be its descendant using a path-component boundary, then derive and record that repository-relative working directory (`.` for the root). Do not derive it from raw `$PWD`, and reject an absolute or parent-traversing result.
-   - Record the current branch, `HEAD`, staged and unstaged diffs, non-ignored untracked-file list, and `git status --porcelain=v1 -z`.
-2. Resolve the selected source remote's expanded fetch URL through GitHub to obtain its canonical repository URL, lowercase host, canonical `<owner>/<repo>`, and default branch; do not infer `github.com` from an unqualified repository name. Also resolve the source branch and tracking ref and the intended `<branch>`, then calculate the qwt repository and target paths with `gh qwt path <owner>/<repo>` and `gh qwt path <owner>/<repo>/<branch>`.
-   - Treat the qwt repository as existing only when `<repository-path>/.bare` is a directory; `gh qwt path` also prints paths for missing repositories and worktrees.
-   - Because qwt paths omit the host, before listing, fetching, adding to, or reusing an existing qwt repository, read the expanded fetch URL for `origin` from its bare Git database, resolve that URL through GitHub, and require the resulting canonical URL and full `<host>/<owner>/<repo>` identity to equal the source repository. Stop if either identity cannot be verified or differs; do not fetch, rewrite `origin`, or reuse a repository belonging to another host. Use an explicitly selected separate qwt root or resolve the collision manually.
-3. Confirm whether the target is a registered worktree by requiring `gh qwt list <owner>/<repo>/<branch> --exact --full-path` to succeed without RTK filtering, then checking whether at least one stdout line equals the calculated target path byte-for-byte. Ignore other returned lines because `--exact` can also match another repository's branch name. Stop if the command fails; empty output or no exact target-path line means that the target is absent. If it exists, verify that its current branch equals the intended branch and stop on a mismatch, then record its staged, unstaged, untracked, and porcelain status before reuse.
-4. Compare the resolved source and target roots before doing any work:
-   - If the target is registered and they are the same worktree, continue there without discarding its current state. Treat an unregistered target as absent even if its calculated path matches the source textually.
-   - Otherwise, if the source or an existing target has uncommitted changes, do not silently leave the source or mix distinct states. Continue an existing dirty target only when the user explicitly identified its changes as the work to continue. Migrate source changes only when the user explicitly chose that outcome, after completing the committed-history check below, preserving staged, unstaged, and non-ignored untracked state and verifying the target before clearing the source. In all other cases, stop and ask how to proceed; never combine two dirty worktrees automatically.
-   - Proceed without migration only when the source is clean and the target is absent or clean.
-5. Whenever the source and target are different, fetch the remote that corresponds to the resolved `<host>/<owner>/<repo>` and compare committed history even when the source is dirty. Use a configured tracking ref only when it belongs to that full repository identity; otherwise use an existing matching `<remote>/<source-branch>`, or the fetched `<remote>/<default-branch>` as the creation base for an unpublished source branch. Compare that ref with the recorded source `HEAD`, for example with `git rev-list --left-right --count <source-ref>...<source-HEAD>`.
-   - Equal commits, or a source that is only behind the ref, have no local-only source history.
-   - A source that is ahead or diverged has local-only commits. Continue only when the user explicitly chose how to publish that exact history, deliberately transfer it to the target, or leave it out; otherwise stop and ask. Never keep working in the ordinary source, or push, rebase, reset, or omit those commits automatically.
-   - Stop if no trustworthy matching remote/base ref can be established.
-6. If the target is missing and the recorded state permits provisioning, use an explicit, host-aware repository. When the qwt repository is missing, always pass the already resolved branch as well as the host: use `gh qwt get --host <host> --branch <default-branch> <owner>/<repo>` for the default branch or replace that branch argument with an existing remote `<branch>`. For a new branch, initialize a missing repository with the explicit host and resolved default branch, reverify the created bare repository's identity as described above, then use `gh qwt add --repo <owner>/<repo> <branch> --from origin/<default-branch>`. When the verified repository already exists, refresh `origin --prune` and record whether `refs/heads/<branch>` plus any `branch.<branch>.remote` and merge configuration already exist before running `gh qwt add --repo <owner>/<repo> <branch>`. `add` reattaches an existing local branch before considering the remote and does not replace it with `--from`; add `--from` only when creating a genuinely new branch.
-7. Before doing any work in a reused or newly attached target, require its expected status, fetch `origin --prune`, and compare target `HEAD` with `origin/<branch>` when that remote branch exists, otherwise with the fetched `origin/<default-branch>` creation base.
-   - If the commits match, continue. If the remote/base is ahead with no target-only commits, fast-forward only when the target is clean by running `git -C <target> merge --ff-only <target-ref>`, then verify equality; if it is dirty, stop and ask instead.
-   - If the target is ahead, diverged, or has local-only history relative to the selected ref, continue only when the user explicitly selected how to use, publish, or reconcile that history. Never reset, rebase, force-push, or overwrite it automatically.
-   - If the remote target branch is missing but the local branch was configured to track it, treat this as a deleted-remote branch and stop for an explicit restore, publish, rename, or abandon decision even when target `HEAD` matches the default-branch base.
-   - Only a branch without prior upstream configuration may be treated automatically as new when target `HEAD` matches the selected creation base; otherwise its local-only history requires the explicit choice above. Stop if no trustworthy target ref can be established.
-8. Resolve the target path again and verify its registered worktree with the exact target-path line test above, then verify its branch, working state, and commit-history decision. Map the recorded source-relative working directory onto the target and require that counterpart to already exist as a directory. Physically resolve it and require the result to equal the resolved target root or be its descendant using a path-component boundary. Stop on a missing or non-directory counterpart, traversal, or symlink escape; do not create it or fall back to the target root. Change to the verified counterpart, confirm `pwd -P` still equals it, and run every subsequent repository command from that directory.
-
-## Comments on Issues / Pull Requests
-
-When posting a comment or reply on an Issue or Pull Request at the user's instruction, always prefix it with `:robot:`.
-
-<!-- rtk-instructions v2 -->
-# RTK — Token-Optimized CLI
-
-**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
-
-## Rule
-
-Always prefix shell commands with `rtk`:
-
-```bash
-# Instead of:              Use:
-git status                 rtk git status
-git log -10                rtk git log -10
-cargo test                 rtk cargo test
-docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl get pods
-```
-
-## Meta commands (use directly)
-
-```bash
-rtk gain              # Token savings dashboard
-rtk gain --history    # Per-command savings history
-rtk discover          # Find missed rtk opportunities
-rtk proxy <cmd>       # Run raw (no filtering) but track usage
-```
-<!-- /rtk-instructions -->
-
-## Raw-output exception
-
-The RTK rule above does not apply when command output or exit status will be parsed, compared for equality, preserved for migration, or otherwise used for a safety decision. Run those commands with `RTK_DISABLED=1 <command>` or, for a simple command, through `rtk proxy <command>`; make decisions only from the raw output and original exit status. For the worktree workflow, this includes every recorded status, diff, ref, path, and list probe; never parse or compare filtered RTK output.
+Running `bash install.sh` replaces the legacy destination with a direct link
+to the canonical file.

--- a/dotfiles/skills/pr-create/SKILL.md
+++ b/dotfiles/skills/pr-create/SKILL.md
@@ -1,20 +1,15 @@
 ---
 name: pr-create
-description: A skill used when creating a Pull Request. This also applies when `/pr create` is invoked. It creates a draft PR according to the repository conventions.
+description: Create a draft GitHub Pull Request from current committed or uncommitted changes in an isolated gh-qwt worktree while preserving source state and following repository conventions. Use only when the user explicitly asks to create, open, prepare, or draft a PR. Within that PR workflow, migrate changes, commit, push, associate an issue, write the description, and assign the requester as needed. Do not use for standalone branch migration, commit, push, issue, or assignment requests without PR intent.
 ---
 
 # pr-create
 
 ## Overview
 
-This skill creates a draft Pull Request (PR) from the current changes.
-It uses `gh-qwt` to give the PR branch its own worktree rather than switching
-branches in a shared checkout.
-
-## When to use
-
-- When asked to "create a PR"
-- When `/pr-create` or `/pr create` is invoked in GitHub Copilot CLI
+Create a draft Pull Request (PR) from the current changes. Use `gh-qwt` to
+give the PR branch its own worktree rather than switching branches in a shared
+checkout.
 
 ## Workspace rules
 
@@ -28,6 +23,10 @@ branches in a shared checkout.
   repository command against that absolute path, for example
   `git -C "$worktree" status`. Do not rely on the invoking directory after the
   target worktree has been selected.
+- Treat repository identity as the canonical GitHub URL plus the canonical
+  `<owner>/<repo>` qualified by its lowercase host. Because qwt paths omit the
+  host, never list, fetch, add to, or reuse an existing qwt repository until
+  its bare `origin` has passed the identity guard in Step 3.
 - Never use `git reset --hard`, force-push, or `gh qwt remove --force` to move
   changes. An unsafe migration must stop with the source worktree or an
   identifiable stash intact.
@@ -38,7 +37,7 @@ branches in a shared checkout.
 
 - First, check whether there is a GitHub Issue (Task) corresponding to this
   change.
-  - Infer the related issue from the context at skill invocation time, the
+  - Infer the related issue from the request context, the
     source branch name, commit messages, and so on.
   - If you can infer it, inspect it with `gh issue view <number> --comments`
     and verify that it matches the changes.
@@ -54,7 +53,7 @@ branches in a shared checkout.
 
 ### Step 2: Understand the source changes deeply
 
-- Treat the checkout in which the skill was invoked as the **source
+- Treat the checkout in which the request originated as the **source
   worktree**. Record its absolute root, current branch, `HEAD`, staged diff,
   unstaged diff, untracked-file list, and `git status --porcelain=v1 -z`
   before changing anything.
@@ -65,7 +64,7 @@ branches in a shared checkout.
   default branch.
 - Read the diff for each file and understand **what** changed and **why**.
   For new files, read the entire file to understand its purpose and role.
-- Consider the context and reasons provided when the skill was invoked. When
+- Consider the context and reasons provided in the request. When
   inferring the change details or background, also refer to the corresponding
   issue description and comments.
 - If the changes span multiple logical units, consider splitting them into
@@ -76,18 +75,33 @@ branches in a shared checkout.
 #### Resolve the repository and source state
 
 1. Confirm that `gh qwt --help` succeeds.
-2. Resolve the canonical GitHub repository and default branch from the source
-   worktree:
-   - `gh repo view --json nameWithOwner,defaultBranchRef`
+2. Read the selected source remote's expanded fetch URL and resolve it through
+   GitHub. Record the returned canonical repository URL, its lowercase host,
+   the canonical `nameWithOwner`, and the default branch. Do not infer
+   `github.com` from an unqualified repository name. Also record:
    - `git -C <source> branch --show-current`
    - `git -C <source> rev-parse HEAD`
 3. Stop if `HEAD` is detached, the repository cannot be resolved by `gh`, or
-   the source branch cannot be determined.
-4. Determine whether a qwt repository already exists by checking that
-   `$(gh qwt path <owner>/<repo>)/.bare` is a directory. A normal clone,
-   including an ordinary linked worktree, is not a qwt repository.
-5. Before using `gh qwt add` in an existing qwt repository, refresh its
-   branch metadata with:
+   the source branch, canonical URL, host, owner, repo, or default branch cannot
+   be determined.
+4. Calculate the qwt repository path with `gh qwt path <owner>/<repo>`. Treat
+   it as existing only when `<qwt-repository>/.bare` is a directory. A normal
+   clone, including an ordinary linked worktree, is not a qwt repository.
+   If the calculated repository path is occupied but `.bare` is absent, stop
+   and report a repository-path collision; do not run `get` inside it.
+5. If the qwt repository exists, guard its identity before inspecting or
+   operating on it:
+   - Read the expanded fetch URL for `origin` directly from
+     `<qwt-repository>/.bare` and resolve that URL through GitHub.
+   - Require both its canonical repository URL and its full
+     `<lowercase-host>/<canonical-owner>/<canonical-repo>` identity to equal
+     the values recorded from the source remote.
+   - Stop if either side cannot be verified or differs. Do not list or fetch
+     the repository, rewrite `origin`, add a worktree, or reuse any existing
+     worktree. Report the host collision and require a separately selected qwt
+     root or manual resolution.
+6. Before using `gh qwt add` in an existing repository, and only after it
+   passes the guard, refresh its branch metadata with:
 
    ```bash
    git -C "$(gh qwt path <owner>/<repo>)" fetch origin --prune
@@ -98,9 +112,10 @@ branches in a shared checkout.
 
 #### Choose the target branch and create its worktree
 
-- If the source is already the qwt worktree for a non-default feature branch,
-  use that worktree as the target. Verify that its checked-out branch matches
-  the branch name; do not create another worktree.
+- If the source appears to be the qwt worktree for a non-default feature
+  branch, select it as the target candidate. It must still pass the exact qwt
+  registration check below; do not trust the calculated path or Git branch
+  alone.
 - Otherwise, derive a new feature branch name from the change. If the name
   cannot be inferred safely, ask the user.
   - The branch name should reflect the changes (for example,
@@ -111,6 +126,16 @@ branches in a shared checkout.
     affect the actual product deliverable, such as build tooling, CI/CD
     configuration, or repository infrastructure. Use an accurate prefix such
     as `docs/*`, `chore/*`, `ci/*`, or `build/*`.
+- After selecting the target branch, calculate its absolute path again. When
+  the guarded qwt repository exists, run
+  `gh qwt list <owner>/<repo>/<target-branch> --exact --full-path` without
+  output filtering and require the command to succeed. Treat the target as a
+  registered worktree only when at least one stdout line equals the calculated
+  target path byte-for-byte; ignore other lines. If it is unregistered but the
+  calculated path is occupied by any file, directory, or link, stop and report
+  a path collision. When the qwt repository is missing, likewise stop before
+  `get` if the calculated target path is already occupied. In the steps below,
+  “target worktree exists” means this exact registration check succeeded.
 - Before migrating a default-branch source, fetch its default branch and
   compare `HEAD` with `origin/<default-branch>`.
   - If the default branch has local commits or the base does not match, stop.
@@ -124,8 +149,19 @@ branches in a shared checkout.
   checkout. Stop if the push is rejected.
 - If the qwt repository does not yet exist:
   - For an existing remote target branch from a non-default source, run
-    `gh qwt get <owner>/<repo> --branch <target-branch>`.
-  - For a new target branch, run `gh qwt get <owner>/<repo>` first, then run
+    `gh qwt get --host <host> --branch <target-branch> <owner>/<repo>`.
+  - For a new target branch, run
+    `gh qwt get --host <host> --branch <default-branch> <owner>/<repo>` first.
+  - After either provisioning command, immediately resolve the new bare
+    repository's `origin` through GitHub and require the same canonical URL
+    and full host/owner/repo identity recorded above. If verification fails,
+    stop before listing, fetching, adding, or reusing it; do not rewrite
+    `origin`.
+  - For a new target branch only, and only after that verification, calculate
+    the default worktree path and require an unfiltered
+    `gh qwt list <owner>/<repo>/<default-branch> --exact --full-path` result to
+    contain it byte-for-byte. Verify that path is a directory on the default
+    branch, then run
     `gh qwt add --repo <owner>/<repo> <target-branch> --from origin/<default-branch>`.
 - If the qwt repository exists but the target worktree does not, run
   `gh qwt add --repo <owner>/<repo> <target-branch>`. Add
@@ -133,9 +169,15 @@ branches in a shared checkout.
 - If a separate target worktree already exists while source changes still
   need migration, stop rather than applying changes over it. Ask the user to
   choose a different target or handle the existing worktree.
-- Resolve the target path with `gh qwt path <owner>/<repo>/<target-branch>`
-  and verify it exists and `git -C <target> branch --show-current` equals the
-  target branch.
+- After a `get` that directly creates the target branch, after every `add`, and
+  again before migration, resolve the target path and repeat the exact
+  unfiltered `gh qwt list` check above. Between the default-branch `get` used
+  to initialize a new repository and the subsequent target-branch `add`, check
+  the default worktree registration as specified above; the target is checked
+  only after `add`. Require the calculated target path to appear byte-for-byte
+  after the applicable creation step, then verify it is a directory and
+  `git -C <target> branch --show-current` equals the target branch. Stop if
+  registration is missing; never reuse an occupied unregistered path.
 - When source and target differ, require
   `git -C <target> status --porcelain` to be empty, then fetch `origin --prune`
   in the target. If `origin/<target-branch>` exists, compare it with local
@@ -157,9 +199,9 @@ non-ignored untracked changes without changing branches.
    non-ignored untracked-file list in a private `mktemp -d` directory. Use
    these snapshots to validate the target after restoration.
 2. Create a uniquely named stash with `git -C <source> stash push
-   --include-untracked -m "copilot-pr-create-migration-<id>"`. Capture both
+   --include-untracked -m "agent-pr-create-migration-<id>"`. Capture both
    the resulting stash object ID and a temporary ref such as
-   `refs/copilot/pr-create-migration/<id>` that points to it with
+   `refs/agent/pr-create-migration/<id>` that points to it with
    `git -C <source> update-ref <temporary-ref> <stash-object-id>`.
 3. If source and target share a qwt common Git directory, restore with
    `git -C <target> stash apply --index <temporary-ref>`.
@@ -182,8 +224,20 @@ non-ignored untracked changes without changing branches.
 
 ### Step 4: Create a commit in the target worktree
 
-- Run `git -C <target> diff --staged --quiet` and commit only when the exit
-  code is 1, meaning staged files exist.
+- Confirm which target changes belong in the PR based on the scope established
+  in Step 2. If the target contains unrelated changes, ask the user which paths
+  to include instead of staging them silently.
+- Stage every intended uncommitted path explicitly, including selected
+  unstaged and non-ignored untracked files restored during migration. Use
+  `git add -A` only when the user has confirmed that the entire target state
+  belongs in this PR.
+- Inspect the full staged diff and verify it matches the intended scope. Then
+  run `git -C <target> diff --staged --quiet` and interpret the exit status:
+  - Exit 1 means staged changes exist; commit them.
+  - Exit 0 means there is nothing to commit. Continue only when the intended
+    changes are already committed on the target branch relative to the PR base;
+    otherwise stop instead of creating an empty PR.
+  - Any other exit status is an error; stop and report it.
 - Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
   format and write the commit message in English.
 - Check recent commits with `git -C <target> log --no-merges --oneline -100`
@@ -245,9 +299,9 @@ non-ignored untracked changes without changing branches.
 
 ### Step 7: Assign the requesting user
 
-- Set the user who invoked the skill as the PR assignee.
+- Set the requesting user as the PR assignee.
 - Use `gh pr edit <PR_NUMBER> --add-assignee <username>` from the target
-  worktree or with an explicit `-R <owner>/<repo>`.
+  worktree or with an explicit `-R <host>/<owner>/<repo>`.
 
 ### Step 8: Align the Issue (Task) description with the final changes
 

--- a/dotfiles/skills/pr-fix/SKILL.md
+++ b/dotfiles/skills/pr-fix/SKILL.md
@@ -1,24 +1,21 @@
 ---
-description: A skill used when fixing a Pull Request. It handles CI failures, review feedback, and merge conflicts. This also applies when `/pr fix`, `/pr fix all`, `/pr fix ci`, `/pr fix feedback`, or `/pr fix conflicts` is invoked.
 name: pr-fix
+description: Bring an existing GitHub Pull Request into a mergeable state from an isolated gh-qwt worktree. Use when asked to fix a PR, resolve merge conflicts, repair failing CI checks, address unresolved review feedback, or run all of these workflows in sequence. Accept a PR number and an optional all, ci, feedback, or conflicts mode.
 ---
 
 # pr-fix
 
-This skill brings a Pull Request into a mergeable state from its own
-`gh-qwt` worktree.
+Bring a Pull Request into a mergeable state from its own `gh-qwt` worktree.
 
-## Usage
+## Inputs
 
-Invoke it with a PR number and an optional mode:
+Accept a PR number and an optional mode:
 
-```text
-/pr fix #42              # Fix everything (conflicts -> ci -> feedback)
-/pr fix all #42          # Same as above (explicit mode)
-/pr fix ci #42           # Fix CI failures only
-/pr fix feedback #42     # Handle review comments only
-/pr fix conflicts #42    # Resolve merge conflicts only
-```
+- Omit the mode or use `all` to fix everything in this order: conflicts, CI,
+  then feedback.
+- Use `ci` to fix CI failures only.
+- Use `feedback` to handle review comments only.
+- Use `conflicts` to resolve merge conflicts only.
 
 ## Prepare the PR worktree
 
@@ -27,23 +24,54 @@ directory is a different worktree.
 
 1. Confirm that `gh qwt --help` succeeds. Do not use `git switch`,
    `git checkout`, `git worktree`, or a normal-clone fallback.
-2. Resolve the base repository from the current GitHub repository context, and
-   retrieve the PR explicitly with:
+2. Resolve the selected base remote's expanded fetch URL through GitHub. Record
+   its canonical repository URL, lowercase host, canonical `nameWithOwner`,
+   and default branch. Define `<base-repository>` as the host-qualified
+   `<base-host>/<base-owner>/<base-repo>`. Do not infer `github.com` from an
+   unqualified repository name, and stop if any part of the base identity
+   cannot be verified.
+3. Retrieve the PR explicitly from that base identity with:
 
    ```bash
-   gh pr view <PR_NUMBER> -R <base-owner>/<base-repo> \
+   gh pr view <PR_NUMBER> -R <base-repository> \
      --json headRefName,headRepository,isCrossRepository,baseRefName,url
    ```
 
-3. Stop and report the error if `headRepository` is null, which commonly
+4. Stop and report the error if `headRepository` is null, which commonly
    means a fork was deleted. Do not create a replacement branch in the base
    repository.
-4. Set the target repository to `headRepository.nameWithOwner` and the target
-   branch to `headRefName`. This is the branch that will receive fixes. Keep
-   the base repository separately for PR API commands.
-5. Resolve the expected target path with
-   `gh qwt path <head-owner>/<head-repo>/<head-branch>`.
-   - If that worktree exists, verify that
+5. Resolve the returned head repository through GitHub on the base host. Record
+   its canonical repository URL, lowercase host, and canonical
+   `nameWithOwner`; stop if any part cannot be verified. Set the target branch
+   to `headRefName`. Use this head identity for all qwt and Git operations, and
+   keep `<base-repository>` separately for PR API commands.
+6. Calculate the qwt repository and target paths with
+   `gh qwt path <head-owner>/<head-repo>` and
+   `gh qwt path <head-owner>/<head-repo>/<head-branch>`. Treat the qwt
+   repository as existing only when `<qwt-repository>/.bare` is a directory.
+   If the calculated repository path is occupied but `.bare` is absent, stop
+   and report a repository-path collision; do not run `get` inside it.
+7. If the qwt repository exists, guard its identity before listing, fetching,
+   adding to, inspecting, or reusing it:
+   - Read the expanded fetch URL for `origin` directly from
+     `<qwt-repository>/.bare` and resolve that URL through GitHub.
+   - Require both its canonical repository URL and its full
+     `<lowercase-host>/<canonical-owner>/<canonical-repo>` identity to equal
+     the recorded head repository identity.
+   - Stop if either side cannot be verified or differs. Do not fetch, rewrite
+     `origin`, add a worktree, or reuse the repository. Report the host
+     collision and require a separately selected qwt root or manual
+     resolution.
+8. Provision or reuse the target only after the identity guard permits it:
+   - When the qwt repository exists, run
+     `gh qwt list <head-owner>/<head-repo>/<head-branch> --exact --full-path`
+     without output filtering and require it to succeed. Treat the target as
+     registered only when at least one stdout line equals the calculated target
+     path byte-for-byte; ignore every other line. If no exact line exists but
+     the path is occupied by a file, directory, or link, stop and report a path
+     collision. When the qwt repository is missing, likewise stop before
+     `get` if its calculated target path is already occupied.
+   - If that worktree is exactly registered, verify that
      `git -C <target> branch --show-current` equals the PR head branch.
      Inspect `git -C <target> status --porcelain`; if it is not empty, stop
      and ask the user how to handle the existing changes.
@@ -54,10 +82,15 @@ directory is a different worktree.
      `gh qwt add --repo <head-owner>/<head-repo> <head-branch>`.
    - If the qwt repository does not exist, clone it directly into the PR head
      branch with
-     `gh qwt get <head-owner>/<head-repo> --branch <head-branch>`.
-   - Resolve the path again with `gh qwt path` and verify both the directory
-     and its checked-out branch.
-6. Fetch `origin --prune` from the resolved target and confirm that
+     `gh qwt get --host <head-host> --branch <head-branch> <head-owner>/<head-repo>`.
+     Immediately run the identity guard against the new bare `origin`; stop
+     before inspecting or reusing the target if verification fails.
+   - After every `get` or `add`, resolve the path again and repeat the exact
+     unfiltered `gh qwt list` check. Require the calculated target path to
+     appear byte-for-byte, then verify both the directory and its checked-out
+     branch. Stop if registration is missing; never substitute an occupied
+     unregistered path.
+9. Fetch `origin --prune` from the resolved target and confirm that
    `origin/<head-branch>` exists. Compare it with local `HEAD` before
    editing:
    - If they match, continue.
@@ -65,13 +98,13 @@ directory is a different worktree.
      `git -C <target> merge --ff-only origin/<head-branch>`.
    - If local `HEAD` is ahead or diverged, stop rather than overwriting,
      force-pushing, or working on a stale PR head.
-7. If `gh-qwt` reports a slash-prefix path collision, cannot find the remote
+10. If `gh-qwt` reports a slash-prefix path collision, cannot find the remote
    branch, or cannot create the worktree, stop and report the qwt error. Do
    not fall back to a branch checkout.
-8. Inspect `git -C <target> status --porcelain` before changing files. If an
+11. Inspect `git -C <target> status --porcelain` before changing files. If an
    existing PR worktree has uncommitted changes, stop and ask the user how to
    handle them; never use `gh qwt remove --force`.
-9. Verify push access to the head repository before making fixes, for example
+12. Verify push access to the head repository before making fixes, for example
    with `git -C <target> push --dry-run origin <head-branch>`. For a fork PR,
    this checks access to the fork rather than assuming the base repository is
    writable. Stop if it is rejected.
@@ -79,8 +112,8 @@ directory is a different worktree.
 All Git commands that inspect, modify, test, commit, or push the PR must use
 the target path. Use `git -C <target> ...` or an equivalent command whose
 working directory is exactly the target worktree. All `gh pr` calls must use
-`-R <base-owner>/<base-repo>` so they continue to address the PR when the
-head is a fork.
+`-R <base-repository>` so they continue to address the canonical base host and
+repository when the head is a fork.
 
 ## Modes
 
@@ -99,7 +132,11 @@ head is a fork.
 - Retrieve `baseRefName` and the base repository during workspace preparation.
 - Fetch the PR base into the target worktree. For a same-repository PR, use
   `origin/<base-ref>`. For a fork PR, configure or reuse an `upstream` remote
-  for the base repository and fetch `upstream/<base-ref>`.
+  for the base repository and fetch `upstream/<base-ref>`. Before fetching a
+  newly configured or reused `upstream`, resolve its expanded fetch URL
+  through GitHub and require its canonical URL and full host/owner/repo
+  identity to equal the recorded base identity. Stop on an unverifiable or
+  mismatched remote instead of rewriting it.
 - Merge the fetched base into the target branch and resolve every conflict
   while preserving the intent of the PR changes. Prefer a merge over a rebase
   so the resulting branch can be pushed without force-pushing.
@@ -113,6 +150,7 @@ head is a fork.
 
 - Retrieve all unresolved review comments from the base repository.
   - Retrieve all replies to review comments as well.
+  - Run every GraphQL query against `<base-host>` explicitly.
   - When retrieving review threads via GraphQL, use
     `reviewThreads(first: 100, after: $cursor)` and inspect
     `pageInfo { hasNextPage endCursor }`.
@@ -144,7 +182,7 @@ head is a fork.
   - Use the retrieved node ID to request a review:
 
     ```bash
-    gh api graphql -f query='
+    gh api graphql --hostname <base-host> -f query='
     mutation {
       requestReviews(input: {
         pullRequestId: "<PR_NODE_ID>",
@@ -179,12 +217,14 @@ Conflicts must be resolved first for CI to run correctly.
 
 ## Common steps (all modes)
 
-### Local review before pushing
+### Perform a local review before pushing
 
-- Before committing and pushing changes, run a local code review using a
-  sub-agent with the `code-review` agent type.
-- Confirm there are no significant issues in the local review before
-  committing and pushing.
+- Before committing and pushing changes, perform an independent local code
+  review. Use an available dedicated review skill or review subagent when the
+  host provides one. Otherwise, perform a distinct review pass over the full
+  diff, checking correctness, regressions, security, and test coverage
+  separately from implementation.
+- Do not commit or push until the review has no unresolved significant issues.
 
 ### Update the PR title and description
 
@@ -198,8 +238,8 @@ Conflicts must be resolved first for CI to run correctly.
 
 ## Constraints
 
-- Keep the PR head worktree after the skill completes so a later `pr-fix` or
-  `pr-merge` invocation can reuse it.
+- Keep the PR head worktree after the skill completes so a later use of
+  `pr-fix` or `pr-merge` can reuse it.
 - Make one commit per logical fix and use a clear message.
 - Do not force-push unless explicitly instructed.
 - Do not use a branch checkout, a normal-clone `git worktree`, or a qwt force

--- a/dotfiles/skills/pr-merge/SKILL.md
+++ b/dotfiles/skills/pr-merge/SKILL.md
@@ -1,51 +1,51 @@
 ---
-description: A skill used to take a Pull Request all the way to merged. It resolves Copilot Code Review feedback in a loop, marks the PR ready for review, applies the `self approval` label, waits for approval and CI, and performs a squash merge. This also applies when `/pr merge` is invoked.
 name: pr-merge
+description: Take one or more GitHub Pull Requests through final review, approval, required CI, squash merge, and safe gh-qwt cleanup. Use when asked to merge PRs once ready, monitor them through merge, loop through Copilot Code Review feedback with the pr-fix skill, apply the self approval workflow, wait for required checks, or process multiple PRs to completion.
 ---
 
 # pr-merge
 
 ## Overview
 
-This skill takes one or more Pull Requests from "ready for final review" to
-"merged". For each PR, it repeatedly runs `pr-fix` and requests a Copilot Code
-Review until there are no unresolved findings. It then marks the PR ready,
-applies the `self approval` label, waits for approval and CI, and squash
-merges it.
+Take one or more Pull Requests from "ready for final review" to "merged". For
+each PR, repeatedly use `pr-fix` and request a Copilot Code Review until there
+are no unresolved findings. Then mark the PR ready, apply the `self approval`
+label, wait for approval and CI, and squash merge it.
 
-The PR head stays in its own `gh-qwt` worktree throughout review, CI, and the
-merge request. After GitHub confirms the merge, the skill removes the clean
-worktree and its local branch through `gh-qwt`, then deletes the head remote
-branch explicitly.
+Keep the PR head in its own `gh-qwt` worktree throughout review, CI, and the
+merge request. After GitHub confirms the merge, remove the clean worktree and
+its local branch through `gh-qwt`, then delete the head remote branch
+explicitly.
 
-## When to use
+## Inputs
 
-- When `/pr-merge` is invoked
-- When asked to merge a PR (or several PRs) once review is clean, for example
-  "merge PR #42 once it's ready" or "run these PRs through to merge"
-
-## Usage
-
-```text
-/pr-merge <PR number> [<PR number> ...]
-```
-
-- One or more PR numbers, separated by spaces
-- Example: `/pr-merge 12 34`
-- PRs are processed one at a time, in the order given
+- Require one or more PR numbers.
+- Process PRs one at a time in the order given.
 
 ## Workspace rules
 
-- Resolve the base repository for each PR and pass it explicitly as
-  `-R <base-owner>/<base-repo>` to every `gh pr` command.
+- Resolve the selected base remote's expanded fetch URL through GitHub for each
+  PR. Record its canonical repository URL, lowercase host, and canonical
+  `nameWithOwner`; define `<base-repository>` as the host-qualified
+  `<base-host>/<base-owner>/<base-repo>`. Stop if the base identity cannot be
+  verified, and pass `-R <base-repository>` to every `gh pr` command.
 - `pr-fix` owns preparation of the PR head worktree. Its `gh-qwt` contract
-  applies to every retry: no `git switch`, `git checkout`, normal-clone
-  fallback, or `git worktree`.
-- Resolve the head repository, head branch, and head SHA again before cleanup
-  with `gh pr view <PR> -R <base-repository> --json
-  headRepository,headRefName,headRefOid`.
+  and full canonical head repository identity guard apply to every retry: no
+  `git switch`, `git checkout`, normal-clone fallback, or `git worktree`.
+- Resolve the head repository, head branch, and head SHA again before cleanup.
+  Resolve the returned head repository through GitHub on the base host and
+  record its canonical URL, lowercase host, and canonical `nameWithOwner`.
+  Stop if this identity cannot be verified or differs from the head identity
+  used by the final `pr-fix` pass.
 - Use `gh qwt path <head-owner>/<head-repo>/<head-branch>` to locate the
   worktree. Never infer its path from the current directory.
+- Before fetching, reusing, removing, or otherwise operating on the cleanup
+  repository, read the expanded `origin` fetch URL directly from its bare Git
+  database and resolve it through GitHub. Require both the canonical URL and
+  full `<lowercase-host>/<canonical-owner>/<canonical-repo>` identity to equal
+  the freshly resolved PR head. Stop before cleanup on an unverifiable or
+  mismatched identity; never rewrite `origin` or act on a host-colliding qwt
+  path.
 - Do not use `gh qwt remove --force`. After a confirmed merge,
   `gh qwt remove --delete-branch` is the required, safe cleanup operation:
   it removes the clean worktree before deleting its now-unchecked-out local
@@ -58,10 +58,16 @@ iterations**. Two conditions send control back to the top of the loop;
 everything else either continues normally or stops and reports (see
 "Retryable vs. non-retryable failures").
 
+Before the first iteration, initialize persistent per-PR approval state outside
+the loop: an unset approval-request timestamp and no recorded approved review.
+Carry both values across every retry; never reset them at the top of the loop.
+
 ### Step 1: Resolve Copilot Code Review feedback
 
-1. Run `/pr-fix all <PR number>`. It provisions or reuses the PR head qwt
-   worktree, resolves merge conflicts, CI failures, and review feedback there.
+1. Use the `pr-fix` skill in `all` mode for the PR number. Let it provision or
+   reuse the PR head qwt worktree and resolve merge conflicts, CI failures,
+   and review feedback there. Retain the canonical head URL and full
+   host/owner/repo identity that its guard verifies during the final pass.
 2. Request a review from Copilot Code Review:
    - Get the PR node ID:
 
@@ -72,7 +78,7 @@ everything else either continues normally or stops and reports (see
    - Request the review:
 
      ```bash
-     gh api graphql -f query='
+     gh api graphql --hostname <base-host> -f query='
      mutation {
        requestReviews(input: {
          pullRequestId: "<PR_NODE_ID>",
@@ -100,6 +106,7 @@ everything else either continues normally or stops and reports (see
    after the request was sent. Use
    `gh pr view <PR_NUMBER> -R <base-repository> --json latestReviews`.
 4. Count the unresolved Copilot Code Review findings:
+   - Run every GraphQL query against `<base-host>` explicitly.
    - Paginate `reviewThreads(first: 100, after: $cursor)`, following
      `pageInfo { hasNextPage endCursor }` until `hasNextPage` is `false`.
    - For each thread, check `isResolved` and the login of the thread's first
@@ -113,20 +120,34 @@ everything else either continues normally or stops and reports (see
 - Run `gh pr ready <PR_NUMBER> -R <base-repository>`.
 - This is idempotent and safe to run again if the loop repeats.
 
-### Step 3: Apply the `self approval` label
+### Step 3: Establish persistent approval state
 
-- Run `gh pr edit <PR_NUMBER> -R <base-repository> --add-label "self approval"`.
-- The label is expected to already exist in the repository. If `gh` reports
-  that it does not exist, stop processing this PR immediately and report the
-  error. Do not create the label or retry; another loop iteration cannot fix
-  it.
+1. Query the current reviews. If an approval is already valid, record its
+   review identity and `submittedAt` in the persistent per-PR state and skip
+   the approval request and wait. On later iterations, retain the recorded
+   approval while the review remains `APPROVED`; do not require a newer review
+   merely because the loop restarted. Clear the recorded approval only if the
+   review no longer remains `APPROVED`.
+2. If no valid approval exists and the approval-request timestamp is unset,
+   record the current time once and run
+   `gh pr edit <PR_NUMBER> -R <base-repository> --add-label "self approval"`.
+   Keep that timestamp for every later iteration. Do not remove and re-add the
+   label or call `--add-label` again to try to retrigger the automation.
+3. Expect the label to already exist in the repository. If `gh` reports that
+   it does not exist, stop processing this PR immediately and report the
+   error. Do not create the label or retry; another loop iteration cannot fix
+   it.
 
 ### Step 4: Wait for bot approval
 
-- Immediately after applying the label, record the current time.
-- Poll once per minute, up to **3 minutes** (3 checks), for a review with
-  `state: APPROVED` whose `submittedAt` is after the recorded time. Use
-  `gh pr view <PR_NUMBER> -R <base-repository> --json reviews` or
+- Skip this step when the persistent state contains a review that remains
+  `APPROVED`.
+- Otherwise, poll once per minute for a review with `state: APPROVED`. When a
+  request was made in Step 3, require a newly observed review to have
+  `submittedAt` at or after the persistent approval-request timestamp, then
+  record its identity and timestamp. Measure the **3-minute** deadline from
+  that one persistent request timestamp, not from the start of each iteration.
+  Use `gh pr view <PR_NUMBER> -R <base-repository> --json reviews` or
   `latestReviews`.
 - If no approval appears within 3 minutes, stop processing this PR immediately
   and report that the self-approval automation is likely not configured or not
@@ -152,25 +173,39 @@ everything else either continues normally or stops and reports (see
 
 ### Step 6: Squash merge, then clean up the qwt branch workspace
 
-1. Retrieve the PR head repository, branch, and SHA again. Stop if the head
-   repository is missing or the PR head changed since the final successful
-   CI/mergeability check.
-2. Resolve the explicit qwt worktree path. Verify all of the following:
+1. Retrieve the PR head repository, branch, and SHA again with
+   `gh pr view <PR_NUMBER> -R <base-repository> --json
+   headRepository,headRefName,headRefOid`. Resolve the returned head repository
+   through GitHub on `<base-host>` and record its canonical URL, lowercase host,
+   and canonical `nameWithOwner`. Stop if the head repository or identity is
+   missing, the identity differs from the final verified `pr-fix` head, or the
+   PR head changed since the final successful CI/mergeability check.
+2. Calculate the qwt repository and explicit worktree paths. Require
+   `<qwt-repository>/.bare` to exist, then run the workspace identity guard
+   against the freshly resolved head before reading the target, fetching, or
+   performing cleanup. Stop on an unverifiable or mismatched `origin`.
+3. Run
+   `gh qwt list <head-owner>/<head-repo>/<head-branch> --exact --full-path`
+   without output filtering and require it to succeed. At least one stdout
+   line must equal the calculated target path byte-for-byte; ignore other
+   lines. Stop before reading, fetching, merging, or cleanup if the target is
+   not exactly registered, even when a directory occupies that path.
+4. Verify all of the following:
    - The path exists and its current branch is the PR head branch.
    - `git -C <target> status --porcelain` is empty.
    - After fetching `origin/<head-branch>`, the local `HEAD`, the
      `origin/<head-branch>` SHA, and the PR `headRefOid` are identical.
-3. Merge with the checked SHA, without `--delete-branch`:
+5. Merge with the checked SHA, without `--delete-branch`:
 
    ```bash
    gh pr merge <PR_NUMBER> -R <base-repository> --squash \
      --match-head-commit <head-ref-oid>
    ```
 
-4. Confirm that the PR is merged before cleanup. If the merge command fails or
+6. Confirm that the PR is merged before cleanup. If the merge command fails or
    the PR remains open, leave the worktree intact and report this PR as
    failed.
-5. Remove the clean worktree and its local branch:
+7. Remove the clean worktree and its local branch:
 
    ```bash
    (
@@ -184,7 +219,12 @@ everything else either continues normally or stops and reports (see
    explicit `owner/repo/branch` spec. Do not pass `--force`. If the worktree
    cannot be removed, the PR is already merged; report a cleanup warning with
    the remaining path instead of reporting a failed merge.
-6. Delete the head branch from its own repository, including for fork PRs:
+8. Resolve the remaining qwt bare `origin` through GitHub again after local
+   cleanup and require its canonical URL and full host/owner/repo identity to
+   still equal the verified head. If the repository is missing or fails this
+   guard, do not contact `origin`; report a cleanup warning while retaining the
+   successful merge result. Otherwise, delete the head branch from its own
+   repository, including for fork PRs:
 
    ```bash
    qwt_repo="$(gh qwt path <head-owner>/<head-repo>)"
@@ -225,12 +265,13 @@ everything else either continues normally or stops and reports (see
 | Merge request fails or PR remains open (Step 6) | Not retryable — stop and report |
 | Loop exceeds 10 iterations | Not retryable — stop and report |
 
-Because `gh pr ready` and `gh pr edit --add-label` are idempotent, and this
-repository's branch protection has `dismiss_stale_reviews_on_push: false`, an
-approval obtained on an earlier iteration is not dismissed by later commits
-from a conflict or CI fix. Re-running Steps 2 through 4 on a later iteration
-is therefore safe, and Step 4 typically resolves immediately because the
-earlier approval remains valid.
+Because this repository's branch protection has
+`dismiss_stale_reviews_on_push: false`, an approval obtained on an earlier
+iteration remains valid after later conflict or CI fixes. Keep the approved
+review identity and timestamp outside the retry loop, confirm that its state
+remains `APPROVED`, and skip the label request and wait while it is valid.
+Although `gh pr ready` is safe to repeat, never reset the approval-request
+timestamp or rely on re-adding the label to trigger another approval.
 
 ## Processing multiple PRs
 

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,29 @@ parse_links() {
 import json, os, sys
 with open(sys.argv[1]) as f:
     data = json.load(f)
-for src, dst in data.get('links', {}).items():
-    print(src + '\t' + dst.replace('~', os.path.expanduser('~')))
+links = data.get('links', {})
+if not isinstance(links, dict):
+    raise TypeError('links must be an object')
+for src, destinations in links.items():
+    if isinstance(destinations, str):
+        destinations = [destinations]
+    elif not isinstance(destinations, list) or not all(isinstance(dst, str) for dst in destinations):
+        raise TypeError('each links value must be a string or an array of strings')
+    for dst in destinations:
+        print(src + '\t' + os.path.expanduser(dst))
+" "$1"
+}
+
+parse_skill_targets() {
+  python3 -c "
+import json, os, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+targets = data.get('skill_targets', [])
+if not isinstance(targets, list) or not all(isinstance(target, str) for target in targets):
+    raise TypeError('skill_targets must be an array of strings')
+for target in targets:
+    print(os.path.expanduser(target))
 " "$1"
 }
 
@@ -22,41 +43,171 @@ ensure_real_parent_dir() {
 
   if [[ -L "${parent}" ]]; then
     local target
-    target="$(readlink "${parent}")"
-    echo "Converting symlink ${parent} to real directory (was -> ${target})"
-    rm "${parent}"
-    mkdir -p "${parent}"
-    if [[ -d "${target}" ]]; then
-      for item in "${target}"/.[!.]* "${target}"/*; do
-        [[ -e "${item}" || -L "${item}" ]] || continue
-        local name
-        name="$(basename "${item}")"
-        if [[ ! -e "${parent}/${name}" && ! -L "${parent}/${name}" ]]; then
-          echo "  Migrating ${item} -> ${parent}/${name}"
-          mv "${item}" "${parent}/${name}"
-        fi
-      done
+    local target_path
+    local resolved_target
+    if ! target="$(readlink "${parent}")"; then
+      echo "Cannot read symlink target for ${parent}" >&2
+      return 1
     fi
+
+    case "${target}" in
+    /*) target_path="${target}" ;;
+    *) target_path="$(dirname "${parent}")/${target}" ;;
+    esac
+
+    # Resolve and validate the target before unlinking the parent. Relative
+    # symlink targets are interpreted from the symlink's directory, not from
+    # the installer's current working directory.
+    if ! resolved_target="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${target_path}")"; then
+      echo "Cannot resolve symlink target ${target} for ${parent}" >&2
+      return 1
+    fi
+    if [[ ! -d "${resolved_target}" ]]; then
+      echo "Cannot convert symlink ${parent}: target ${target} is not an existing directory" >&2
+      return 1
+    fi
+
+    echo "Converting symlink ${parent} to real directory (was -> ${target})"
+    rm "${parent}" || return 1
+    mkdir -p "${parent}" || return 1
+    for item in \
+      "${resolved_target}"/.[!.]* \
+      "${resolved_target}"/..?* \
+      "${resolved_target}"/*; do
+      [[ -e "${item}" || -L "${item}" ]] || continue
+      local name
+      name="$(basename "${item}")"
+      if [[ ! -e "${parent}/${name}" && ! -L "${parent}/${name}" ]]; then
+        echo "  Migrating ${item} -> ${parent}/${name}"
+        mv "${item}" "${parent}/${name}" || return 1
+      fi
+    done
   else
     mkdir -p "${parent}"
   fi
 }
 
-MAP_FILE="${DIR}/install_map.json"
+# Previous versions linked the entire canonical skills directory into Copilot.
+# Remove only that exact legacy link. In particular, do not run the generic
+# parent-directory migration for it: doing so would move the canonical sources.
+cleanup_legacy_copilot_skills() {
+  local legacy_path="${HOME}/.copilot/skills"
+  local canonical_skills="${DIR}/dotfiles/skills"
 
-while IFS=$'\t' read -r src dst; do
-  full_src="${DIR}/dotfiles/${src}"
+  [[ -L "${legacy_path}" ]] || return 0
 
-  ensure_real_parent_dir "${dst}"
-
-  if [[ -e "${dst}" || -L "${dst}" ]]; then
-    echo "Removing existing ${dst}"
-    rm -rf "${dst}"
+  local resolved_legacy
+  local resolved_canonical
+  if ! resolved_legacy="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${legacy_path}")"; then
+    echo "Cannot resolve legacy skills link ${legacy_path}" >&2
+    return 1
+  fi
+  if ! resolved_canonical="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${canonical_skills}")"; then
+    echo "Cannot resolve canonical skills directory ${canonical_skills}" >&2
+    return 1
   fi
 
-  echo "Linking ${full_src} -> ${dst}"
-  ln -s "${full_src}" "${dst}"
-done < <(parse_links "${MAP_FILE}")
+  if [[ "${resolved_legacy}" == "${resolved_canonical}" ]]; then
+    echo "Removing legacy skills link ${legacy_path}"
+    rm "${legacy_path}"
+  fi
+}
+
+link_skills_into() {
+  local target_root="$1"
+  local canonical_skills="${DIR}/dotfiles/skills"
+  local skill_src
+  local skill_name
+  local dst
+  local resolved_dst
+  local resolved_skill
+
+  mkdir -p "${target_root}" || return 1
+
+  # Include hidden source directories if they are valid skills. Unmatched
+  # globs are discarded by the directory/SKILL.md checks.
+  for skill_src in \
+    "${canonical_skills}"/* \
+    "${canonical_skills}"/.[!.]* \
+    "${canonical_skills}"/..?*; do
+    [[ -d "${skill_src}" && -f "${skill_src}/SKILL.md" ]] || continue
+
+    skill_name="$(basename "${skill_src}")"
+    dst="${target_root}/${skill_name}"
+
+    # A target root may itself already be a legacy whole-directory symlink.
+    # In that case dst resolves to the canonical source directory; deleting it
+    # would delete the source rather than a destination entry.
+    if [[ -e "${dst}" ]]; then
+      if ! resolved_dst="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${dst}")"; then
+        echo "Cannot resolve existing skill destination ${dst}" >&2
+        return 1
+      fi
+      if ! resolved_skill="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "${skill_src}")"; then
+        echo "Cannot resolve canonical skill directory ${skill_src}" >&2
+        return 1
+      fi
+      if [[ "${resolved_dst}" == "${resolved_skill}" ]]; then
+        echo "Skill ${skill_name} is already available through ${target_root}"
+        continue
+      fi
+    fi
+
+    if [[ -e "${dst}" || -L "${dst}" ]]; then
+      echo "Removing existing ${dst}"
+      rm -rf "${dst}" || return 1
+    fi
+
+    echo "Linking ${skill_src} -> ${dst}"
+    ln -s "${skill_src}" "${dst}" || return 1
+  done
+}
+
+MAP_FILE="${DIR}/install_map.json"
+
+PARSED_LINKS=""
+PARSED_SKILL_TARGETS=""
+if ! PARSED_LINKS="$(parse_links "${MAP_FILE}")"; then
+  echo "Cannot parse links from ${MAP_FILE}" >&2
+  exit 1
+fi
+if ! PARSED_SKILL_TARGETS="$(parse_skill_targets "${MAP_FILE}")"; then
+  echo "Cannot parse skill targets from ${MAP_FILE}" >&2
+  exit 1
+fi
+
+if [[ -n "${PARSED_LINKS}" ]]; then
+  while IFS=$'\t' read -r src dst; do
+    full_src="${DIR}/dotfiles/${src}"
+
+    if ! ensure_real_parent_dir "${dst}"; then
+      exit 1
+    fi
+
+    if [[ -e "${dst}" || -L "${dst}" ]]; then
+      echo "Removing existing ${dst}"
+      rm -rf "${dst}" || exit 1
+    fi
+
+    echo "Linking ${full_src} -> ${dst}"
+    ln -s "${full_src}" "${dst}" || exit 1
+  done <<<"${PARSED_LINKS}"
+fi
+
+if [[ -n "${PARSED_SKILL_TARGETS}" ]]; then
+  while IFS= read -r target_root; do
+    if ! link_skills_into "${target_root}"; then
+      exit 1
+    fi
+  done <<<"${PARSED_SKILL_TARGETS}"
+
+  # Keep the old Copilot discovery path available until every replacement link
+  # has been installed successfully. An empty target list provides no
+  # replacement discovery path, so it must not trigger legacy cleanup.
+  if ! cleanup_legacy_copilot_skills; then
+    exit 1
+  fi
+fi
 
 is_brew_dependent_100_script() {
   case "$(basename "$1")" in

--- a/install_map.json
+++ b/install_map.json
@@ -8,8 +8,15 @@
     "nvim": "~/.config/nvim",
     "sheldon": "~/.config/sheldon",
     "starship.toml": "~/.config/starship.toml",
-    "skills": "~/.copilot/skills",
-    "copilot-instructions.md": "~/.copilot/copilot-instructions.md",
+    "agent-instructions.md": [
+      "~/.copilot/copilot-instructions.md",
+      "~/.codex/AGENTS.md",
+      "~/.claude/CLAUDE.md"
+    ],
     "copilot-hooks/rtk-rewrite.json": "~/.copilot/hooks/rtk-rewrite.json"
-  }
+  },
+  "skill_targets": [
+    "~/.agents/skills",
+    "~/.claude/skills"
+  ]
 }

--- a/tests/agent_configuration.bats
+++ b/tests/agent_configuration.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+
+@test "repository instruction adapters point to canonical AGENTS files" {
+  [ -f "${REPO_ROOT}/AGENTS.md" ]
+  [ -f "${REPO_ROOT}/.github/workflows/AGENTS.md" ]
+
+  [ "$(<"${REPO_ROOT}/CLAUDE.md")" = "@AGENTS.md" ]
+  grep -Fxq '@../AGENTS.md' \
+    "${REPO_ROOT}/.github/copilot-instructions.md"
+  grep -Fq '[`../workflows/AGENTS.md`](../workflows/AGENTS.md)' \
+    "${REPO_ROOT}/.github/instructions/actions.instructions.md"
+  grep -Fq '@../../.github/workflows/AGENTS.md' \
+    "${REPO_ROOT}/.claude/rules/github-actions.md"
+}
+
+@test "legacy Copilot personal source forwards to canonical instructions" {
+  [ -f "${REPO_ROOT}/dotfiles/agent-instructions.md" ]
+  grep -Fq 'sibling `agent-instructions.md`' \
+    "${REPO_ROOT}/dotfiles/copilot-instructions.md"
+}

--- a/tests/install_map.bats
+++ b/tests/install_map.bats
@@ -7,7 +7,13 @@ REPO_ROOT="${BATS_TEST_DIRNAME}/.."
 MAP_FILE="${REPO_ROOT}/install_map.json"
 
 @test "install_map.json is valid JSON with a links object" {
-  run jq -e '.links | type == "object"' "$MAP_FILE"
+  run jq -e '
+    (.links | type == "object") and
+    (all(.links[];
+      (type == "string") or
+      (type == "array" and all(.[]; type == "string"))
+    ))
+  ' "$MAP_FILE"
   [ "$status" -eq 0 ]
   [ "$output" = "true" ]
 }
@@ -21,8 +27,39 @@ MAP_FILE="${REPO_ROOT}/install_map.json"
 @test "every dst entry is an absolute or ~-rooted path" {
   while IFS= read -r dst; do
     case "$dst" in
-    "~/"* | /*) ;;
+    \~/* | /*) ;;
     *) return 1 ;;
     esac
-  done < <(jq -r '.links | values[]' "$MAP_FILE")
+  done < <(jq -r '.links | values[] | if type == "array" then .[] else . end' "$MAP_FILE")
+}
+
+@test "agent instructions are shared with Copilot, Codex, and Claude Code" {
+  run jq -e '
+    .links["agent-instructions.md"] as $targets |
+    ($targets | type == "array") and
+    ([
+      "~/.copilot/copilot-instructions.md",
+      "~/.codex/AGENTS.md",
+      "~/.claude/CLAUDE.md"
+    ] - $targets | length == 0)
+  ' "$MAP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "skill_targets is an array of absolute or ~-rooted paths" {
+  run jq -e '
+    (.skill_targets | type == "array" and length > 0) and
+    all(.skill_targets[]; type == "string") and
+    (["~/.agents/skills", "~/.claude/skills"] - .skill_targets | length == 0)
+  ' "$MAP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  while IFS= read -r target; do
+    case "$target" in
+    \~/* | /*) ;;
+    *) return 1 ;;
+    esac
+  done < <(jq -r '.skill_targets[]' "$MAP_FILE")
 }

--- a/tests/install_symlinks.bats
+++ b/tests/install_symlinks.bats
@@ -23,17 +23,18 @@ setup() {
 }
 
 teardown() {
-  cd "$ORIGINAL_DIR"
+  cd "$ORIGINAL_DIR" || return
   rm -rf "$SANDBOX" "$FAKE_HOME"
 }
 
 write_install_map() {
-  # write_install_map '{"a.txt": "~/dst-a.txt", ...}'
-  printf '{"links": %s}\n' "$1" >"${SANDBOX}/install_map.json"
+  # write_install_map '{"a.txt": "~/dst-a.txt", ...}' '["~/.agents/skills"]'
+  local skill_targets="${2:-[]}"
+  printf '{"links": %s, "skill_targets": %s}\n' "$1" "$skill_targets" >"${SANDBOX}/install_map.json"
 }
 
 run_install() {
-  HOME="$FAKE_HOME" bash "${SANDBOX}/install.sh"
+  HOME="$FAKE_HOME" /bin/bash "${SANDBOX}/install.sh"
 }
 
 @test "creates a symlink for each mapping in install_map.json" {
@@ -53,6 +54,22 @@ run_install() {
   # ~/nested did not exist beforehand: mkdir -p must have created it.
   [ -L "${FAKE_HOME}/nested/dst-b.txt" ]
   [ "$(cat "${FAKE_HOME}/nested/dst-b.txt")" = "hello-b" ]
+}
+
+@test "creates every destination when a mapping contains an array" {
+  printf 'shared\n' >"${SANDBOX}/dotfiles/shared.txt"
+  write_install_map '{"shared.txt": ["~/.copilot/instructions.md", "~/.codex/AGENTS.md", "~/.claude/CLAUDE.md"]}'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  for dst in \
+    "${FAKE_HOME}/.copilot/instructions.md" \
+    "${FAKE_HOME}/.codex/AGENTS.md" \
+    "${FAKE_HOME}/.claude/CLAUDE.md"; do
+    [ -L "$dst" ]
+    [ "$(readlink "$dst")" = "${SANDBOX}/dotfiles/shared.txt" ]
+  done
 }
 
 @test "re-running install.sh is idempotent" {
@@ -77,6 +94,7 @@ run_install() {
   # already has unrelated content in it.
   mkdir -p "${FAKE_HOME}/.config" "${FAKE_HOME}/tool-target"
   printf 'keep-me\n' >"${FAKE_HOME}/tool-target/existing.txt"
+  printf 'keep-hidden\n' >"${FAKE_HOME}/tool-target/..existing"
   ln -s "${FAKE_HOME}/tool-target" "${FAKE_HOME}/.config/tool"
 
   run run_install
@@ -90,9 +108,295 @@ run_install() {
   # Pre-existing content was migrated in, not lost.
   [ -f "${FAKE_HOME}/.config/tool/existing.txt" ]
   [ "$(cat "${FAKE_HOME}/.config/tool/existing.txt")" = "keep-me" ]
+  [ "$(cat "${FAKE_HOME}/.config/tool/..existing")" = "keep-hidden" ]
   [ ! -e "${FAKE_HOME}/tool-target/existing.txt" ]
+  [ ! -e "${FAKE_HOME}/tool-target/..existing" ]
 
   # The new mapping was linked inside the now-real directory.
   [ -L "${FAKE_HOME}/.config/tool/c.txt" ]
   [ "$(cat "${FAKE_HOME}/.config/tool/c.txt")" = "fixture-c" ]
+}
+
+@test "resolves a relative parent symlink target from the symlink directory" {
+  printf 'fixture-relative\n' >"${SANDBOX}/dotfiles/relative.txt"
+  write_install_map '{"relative.txt": "~/.config/tool/relative.txt"}'
+
+  mkdir -p "${FAKE_HOME}/.config" "${FAKE_HOME}/tool-target"
+  printf 'keep-relative\n' >"${FAKE_HOME}/tool-target/existing.txt"
+  ln -s "../tool-target" "${FAKE_HOME}/.config/tool"
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  [ ! -L "${FAKE_HOME}/.config/tool" ]
+  [ -d "${FAKE_HOME}/.config/tool" ]
+  [ "$(cat "${FAKE_HOME}/.config/tool/existing.txt")" = "keep-relative" ]
+  [ ! -e "${FAKE_HOME}/tool-target/existing.txt" ]
+  [ -L "${FAKE_HOME}/.config/tool/relative.txt" ]
+  [ "$(cat "${FAKE_HOME}/.config/tool/relative.txt")" = "fixture-relative" ]
+}
+
+@test "leaves a dangling parent symlink intact and fails installation" {
+  printf 'fixture-dangling\n' >"${SANDBOX}/dotfiles/dangling.txt"
+  write_install_map '{"dangling.txt": "~/.config/tool/dangling.txt"}'
+
+  mkdir -p "${FAKE_HOME}/.config"
+  ln -s "../missing-target" "${FAKE_HOME}/.config/tool"
+
+  run run_install
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not an existing directory"* ]]
+  [ -L "${FAKE_HOME}/.config/tool" ]
+  [ "$(readlink "${FAKE_HOME}/.config/tool")" = "../missing-target" ]
+  [ ! -e "${FAKE_HOME}/.config/tool/dangling.txt" ]
+}
+
+@test "leaves a parent symlink to a non-directory intact and fails installation" {
+  printf 'fixture-invalid\n' >"${SANDBOX}/dotfiles/invalid.txt"
+  write_install_map '{"invalid.txt": "~/.config/tool/invalid.txt"}'
+
+  mkdir -p "${FAKE_HOME}/.config"
+  printf 'not a directory\n' >"${FAKE_HOME}/not-a-directory"
+  ln -s "../not-a-directory" "${FAKE_HOME}/.config/tool"
+
+  run run_install
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not an existing directory"* ]]
+  [ -L "${FAKE_HOME}/.config/tool" ]
+  [ "$(readlink "${FAKE_HOME}/.config/tool")" = "../not-a-directory" ]
+  [ "$(cat "${FAKE_HOME}/not-a-directory")" = "not a directory" ]
+}
+
+@test "keeps the canonical legacy skills link when a later mapping fails" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot" \
+    "${FAKE_HOME}/.config"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  printf 'fixture-failure\n' >"${SANDBOX}/dotfiles/failure.txt"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.copilot/skills"
+  ln -s "../missing-target" "${FAKE_HOME}/.config/tool"
+  write_install_map '{"failure.txt": "~/.config/tool/failure.txt"}' '["~/.agents/skills"]'
+
+  run run_install
+
+  [ "$status" -ne 0 ]
+  [ -L "${FAKE_HOME}/.copilot/skills" ]
+  [ "$(readlink "${FAKE_HOME}/.copilot/skills")" = "${SANDBOX}/dotfiles/skills" ]
+  [ -f "${FAKE_HOME}/.copilot/skills/managed/SKILL.md" ]
+  [ ! -e "${FAKE_HOME}/.agents/skills/managed" ]
+}
+
+@test "propagates skill target creation failure and keeps the legacy link" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  printf 'blocks skill root\n' >"${FAKE_HOME}/.agents"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.copilot/skills"
+  write_install_map '{}' '["~/.agents/skills"]'
+
+  run run_install
+
+  [ "$status" -ne 0 ]
+  [ -L "${FAKE_HOME}/.copilot/skills" ]
+  [ "$(readlink "${FAKE_HOME}/.copilot/skills")" = "${SANDBOX}/dotfiles/skills" ]
+  [ -f "${FAKE_HOME}/.copilot/skills/managed/SKILL.md" ]
+}
+
+@test "invalid JSON performs no mapped mutations and keeps the legacy link" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  printf 'mapped source\n' >"${SANDBOX}/dotfiles/mapped.txt"
+  printf 'keep destination\n' >"${FAKE_HOME}/mapped.txt"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.copilot/skills"
+  printf '%s\n' '{"links":{"mapped.txt":"~/mapped.txt"},"skill_targets":[' >"${SANDBOX}/install_map.json"
+
+  run run_install
+
+  [ "$status" -ne 0 ]
+  [ "$(cat "${FAKE_HOME}/mapped.txt")" = "keep destination" ]
+  [ -L "${FAKE_HOME}/.copilot/skills" ]
+  [ "$(readlink "${FAKE_HOME}/.copilot/skills")" = "${SANDBOX}/dotfiles/skills" ]
+}
+
+@test "skill target parser failure occurs before mapped mutations" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  printf 'mapped source\n' >"${SANDBOX}/dotfiles/mapped.txt"
+  printf 'keep destination\n' >"${FAKE_HOME}/mapped.txt"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.copilot/skills"
+  write_install_map '{"mapped.txt": "~/mapped.txt"}' '[42]'
+
+  run run_install
+
+  [ "$status" -ne 0 ]
+  [ "$(cat "${FAKE_HOME}/mapped.txt")" = "keep destination" ]
+  [ -L "${FAKE_HOME}/.copilot/skills" ]
+  [ "$(readlink "${FAKE_HOME}/.copilot/skills")" = "${SANDBOX}/dotfiles/skills" ]
+}
+
+@test "realpath helper failure keeps the legacy link and fails installation" {
+  local real_python3
+  real_python3="$(command -v python3)"
+
+  mkdir -p \
+    "${SANDBOX}/bin" \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.copilot/skills"
+  write_install_map '{}' '["~/.agents/skills"]'
+
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'if [[ "$2" == *"os.path.realpath"* ]]; then' \
+    '  exit 42' \
+    'fi' \
+    'exec "${REAL_PYTHON3}" "$@"' >"${SANDBOX}/bin/python3"
+  chmod +x "${SANDBOX}/bin/python3"
+
+  run env \
+    HOME="${FAKE_HOME}" \
+    PATH="${SANDBOX}/bin:${PATH}" \
+    REAL_PYTHON3="${real_python3}" \
+    /bin/bash "${SANDBOX}/install.sh"
+
+  [ "$status" -ne 0 ]
+  [ -L "${FAKE_HOME}/.copilot/skills" ]
+  [ "$(readlink "${FAKE_HOME}/.copilot/skills")" = "${SANDBOX}/dotfiles/skills" ]
+  [ -f "${FAKE_HOME}/.copilot/skills/managed/SKILL.md" ]
+}
+
+@test "links valid skills individually into every target root" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/alpha" \
+    "${SANDBOX}/dotfiles/skills/bravo" \
+    "${SANDBOX}/dotfiles/skills/not-a-skill"
+  printf '%s\n' '---' 'name: alpha' '---' >"${SANDBOX}/dotfiles/skills/alpha/SKILL.md"
+  printf '%s\n' '---' 'name: bravo' '---' >"${SANDBOX}/dotfiles/skills/bravo/SKILL.md"
+  printf 'ignored\n' >"${SANDBOX}/dotfiles/skills/not-a-skill/README.md"
+  write_install_map '{}' '["~/.agents/skills", "~/.claude/skills"]'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  for root in "${FAKE_HOME}/.agents/skills" "${FAKE_HOME}/.claude/skills"; do
+    [ -d "$root" ]
+    [ ! -L "$root" ]
+    [ -L "${root}/alpha" ]
+    [ "$(readlink "${root}/alpha")" = "${SANDBOX}/dotfiles/skills/alpha" ]
+    [ -L "${root}/bravo" ]
+    [ "$(readlink "${root}/bravo")" = "${SANDBOX}/dotfiles/skills/bravo" ]
+    [ ! -e "${root}/not-a-skill" ]
+  done
+}
+
+@test "skill installation preserves unrelated and reserved entries" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.agents/skills/.system" \
+    "${FAKE_HOME}/.agents/skills/unrelated" \
+    "${FAKE_HOME}/.agents/skills/managed"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  printf 'reserved\n' >"${FAKE_HOME}/.agents/skills/.system/keep.txt"
+  printf 'unrelated\n' >"${FAKE_HOME}/.agents/skills/unrelated/keep.txt"
+  printf 'replace me\n' >"${FAKE_HOME}/.agents/skills/managed/stale.txt"
+  write_install_map '{}' '["~/.agents/skills"]'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "${FAKE_HOME}/.agents/skills/.system/keep.txt")" = "reserved" ]
+  [ "$(cat "${FAKE_HOME}/.agents/skills/unrelated/keep.txt")" = "unrelated" ]
+  [ -L "${FAKE_HOME}/.agents/skills/managed" ]
+  [ ! -e "${FAKE_HOME}/.agents/skills/managed/stale.txt" ]
+}
+
+@test "skill installation is idempotent" {
+  mkdir -p "${SANDBOX}/dotfiles/skills/managed"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  write_install_map '{}' '["~/.agents/skills", "~/.claude/skills"]'
+
+  run run_install
+  [ "$status" -eq 0 ]
+  run run_install
+  [ "$status" -eq 0 ]
+
+  [ -L "${FAKE_HOME}/.agents/skills/managed" ]
+  [ "$(readlink "${FAKE_HOME}/.agents/skills/managed")" = "${SANDBOX}/dotfiles/skills/managed" ]
+  [ -L "${FAKE_HOME}/.claude/skills/managed" ]
+  [ "$(readlink "${FAKE_HOME}/.claude/skills/managed")" = "${SANDBOX}/dotfiles/skills/managed" ]
+}
+
+@test "does not delete canonical skills through an aliased target root" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.agents"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.agents/skills"
+  write_install_map '{}' '["~/.agents/skills"]'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  [ -L "${FAKE_HOME}/.agents/skills" ]
+  [ -f "${SANDBOX}/dotfiles/skills/managed/SKILL.md" ]
+}
+
+@test "removes only the legacy Copilot skills link to the canonical source" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.copilot/skills"
+  write_install_map '{}' '["~/.agents/skills"]'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  [ ! -e "${FAKE_HOME}/.copilot/skills" ]
+  [ ! -L "${FAKE_HOME}/.copilot/skills" ]
+  [ -f "${SANDBOX}/dotfiles/skills/managed/SKILL.md" ]
+  [ -L "${FAKE_HOME}/.agents/skills/managed" ]
+}
+
+@test "leaves an unrelated legacy Copilot skills path untouched" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot" \
+    "${FAKE_HOME}/other-skills/external"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  printf 'keep\n' >"${FAKE_HOME}/other-skills/external/keep.txt"
+  ln -s "${FAKE_HOME}/other-skills" "${FAKE_HOME}/.copilot/skills"
+  write_install_map '{}' '["~/.agents/skills"]'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  [ -L "${FAKE_HOME}/.copilot/skills" ]
+  [ "$(readlink "${FAKE_HOME}/.copilot/skills")" = "${FAKE_HOME}/other-skills" ]
+  [ "$(cat "${FAKE_HOME}/.copilot/skills/external/keep.txt")" = "keep" ]
+}
+
+@test "keeps the legacy Copilot skills link without replacement targets" {
+  mkdir -p \
+    "${SANDBOX}/dotfiles/skills/managed" \
+    "${FAKE_HOME}/.copilot"
+  printf '%s\n' '---' 'name: managed' '---' >"${SANDBOX}/dotfiles/skills/managed/SKILL.md"
+  ln -s "${SANDBOX}/dotfiles/skills" "${FAKE_HOME}/.copilot/skills"
+  write_install_map '{}' '[]'
+
+  run run_install
+
+  [ "$status" -eq 0 ]
+  [ -L "${FAKE_HOME}/.copilot/skills" ]
+  [ "$(readlink "${FAKE_HOME}/.copilot/skills")" = "${SANDBOX}/dotfiles/skills" ]
+  [ -f "${FAKE_HOME}/.copilot/skills/managed/SKILL.md" ]
 }


### PR DESCRIPTION
## Summary

- share canonical personal, repository, and path-scoped instructions across GitHub Copilot, Codex, and Claude Code through thin adapters
- install each shared Agent Skill into product discovery roots without replacing unrelated skill directories, while migrating the legacy Copilot-wide link safely
- harden the `gh-qwt` PR workflows with canonical host/repository identity checks, exact registered-worktree validation, and preserved migration state
- retain the self-approval request and timestamp across `pr-merge` retry cycles

## Why

The repository previously treated GitHub Copilot paths as the primary source for instructions and skills. Supporting multiple coding agents with duplicated files would let safety procedures drift, while linking an entire skill root could hide built-in or independently installed skills.

This change adopts product-neutral canonical files, per-product adapters, and per-skill links. It also tightens the PR workflows so host/path collisions and stale qwt state stop safely instead of operating on an ambiguous workspace.

## Impact

| Area | Result |
| --- | --- |
| Instructions | One canonical repository file and one canonical personal file serve all three agents |
| Skills | Shared skills are linked individually into `~/.agents/skills/` and `~/.claude/skills/` |
| Installer | `links` accepts one or multiple destinations, and `skill_targets` controls per-skill discovery roots |
| PR workflows | qwt repository identity, worktree registration, migration, and retry state are validated explicitly |
| Documentation | Guides, references, testing coverage, and ADRs describe the new architecture and operation |

> [!NOTE]
> GitHub Copilot prioritizes a same-named skill under `~/.copilot/skills/` over the shared `~/.agents/skills/` copy. The installer preserves independently managed Copilot content; the documentation explains how to remove or rename a conflicting entry.

## Validation

- [x] `git diff --check`
- [x] `shellcheck install.sh scripts/*.sh dotfiles/zsh/starship-qwt-worktree.sh`
- [x] `zsh -n` for all `dotfiles/zsh/*.zsh`
- [x] `jq empty install_map.json`
- [x] TOML parsing with the mise-managed Python
- [x] `bats tests` — 31/31 passed
- [x] `bun run --cwd .docusaurus build`

> [!NOTE]
> Live interactive discovery and invocation in all three agent products was not run in this automated session.